### PR TITLE
fix(author): assessment-only Correct Answer Popup + 24000-byte Description cap

### DIFF
--- a/project/ws/author/src/lib/modules/shared/validators/byte-length.validator.spec.ts
+++ b/project/ws/author/src/lib/modules/shared/validators/byte-length.validator.spec.ts
@@ -1,0 +1,55 @@
+import { FormControl } from '@angular/forms'
+
+import { MAX_INSTRUCTIONS_BYTES, maxByteLengthValidator, utf8ByteLength } from './byte-length.validator'
+
+describe('byte-length.validator', () => {
+  describe('utf8ByteLength', () => {
+    it('returns 0 for null / undefined / empty', () => {
+      expect(utf8ByteLength(null)).toBe(0)
+      expect(utf8ByteLength(undefined)).toBe(0)
+      expect(utf8ByteLength('')).toBe(0)
+    })
+
+    it('counts ASCII as 1 byte/char', () => {
+      expect(utf8ByteLength('hello')).toBe(5)
+    })
+
+    it('counts Devanagari (Hindi) as ~3 bytes/char', () => {
+      // "स्तन" — multibyte; must be > its character length
+      const text = 'स्तन'
+      expect(utf8ByteLength(text)).toBeGreaterThan(text.length)
+      expect(utf8ByteLength('क')).toBe(3)
+    })
+  })
+
+  describe('maxByteLengthValidator', () => {
+    const validate = maxByteLengthValidator(MAX_INSTRUCTIONS_BYTES)
+
+    it('passes when under the byte limit', () => {
+      expect(validate(new FormControl('a short description'))).toBeNull()
+    })
+
+    it('passes for empty value (required-ness is a separate validator)', () => {
+      expect(validate(new FormControl(''))).toBeNull()
+    })
+
+    it('fails when over the byte limit and reports actual/max bytes', () => {
+      const big = 'a'.repeat(MAX_INSTRUCTIONS_BYTES + 1)
+      const result = validate(new FormControl(big))
+      expect(result).toEqual({ maxByteLength: { maxBytes: MAX_INSTRUCTIONS_BYTES, actualBytes: MAX_INSTRUCTIONS_BYTES + 1 } })
+    })
+
+    it('measures bytes (not characters) — multibyte content trips the limit sooner', () => {
+      // ~9,000 Devanagari chars => ~27,000 bytes (> 24,000) even though char count < limit
+      const hindi = 'क'.repeat(9000)
+      expect(hindi.length).toBeLessThan(MAX_INSTRUCTIONS_BYTES)
+      const result = maxByteLengthValidator(MAX_INSTRUCTIONS_BYTES)(new FormControl(hindi))
+      expect(result).not.toBeNull()
+      expect(result!['maxByteLength'].actualBytes).toBe(27000)
+    })
+
+    it('stays under the Elasticsearch 32,766-byte keyword limit with headroom', () => {
+      expect(MAX_INSTRUCTIONS_BYTES).toBeLessThan(32766)
+    })
+  })
+})

--- a/project/ws/author/src/lib/modules/shared/validators/byte-length.validator.ts
+++ b/project/ws/author/src/lib/modules/shared/validators/byte-length.validator.ts
@@ -1,0 +1,31 @@
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms'
+
+/**
+ * Max UTF-8 byte length for rich-text/description fields (e.g. course `instructions`).
+ *
+ * Elasticsearch keyword sub-fields (the composite-search `instructions.raw`) reject any
+ * single term whose UTF-8 encoding exceeds 32,766 bytes with an `illegal_argument_exception`
+ * ("immense term"), which crash-loops the Sunbird search-indexer Flink job and stops ALL
+ * content from being indexed. We cap well under that limit, leaving headroom for HTML markup
+ * and multibyte scripts (e.g. Devanagari is ~3 bytes/char).
+ */
+export const MAX_INSTRUCTIONS_BYTES = 24000
+
+/** UTF-8 byte length of a string (multibyte-safe). Empty/null => 0. */
+export function utf8ByteLength(value: string | null | undefined): number {
+  if (!value) {
+    return 0
+  }
+  return new TextEncoder().encode(value).length
+}
+
+/**
+ * Validator that fails when the control value's UTF-8 byte length exceeds `maxBytes`.
+ * Error shape: `{ maxByteLength: { maxBytes, actualBytes } }`.
+ */
+export function maxByteLengthValidator(maxBytes: number): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const actualBytes = utf8ByteLength(control.value)
+    return actualBytes > maxBytes ? { maxByteLength: { maxBytes, actualBytes } } : null
+  }
+}

--- a/project/ws/author/src/lib/routing/modules/editor/routing/modules/collection/components/collection/module-creation/module-creation.component.html
+++ b/project/ws/author/src/lib/routing/modules/editor/routing/modules/collection/components/collection/module-creation/module-creation.component.html
@@ -11,1149 +11,1747 @@
     <div class="mc-builder">
       <div class="mc-left-col">
         <mat-drawer-container [class.drawer-opened]="drawer.opened">
-        <mat-drawer #drawer class="drawer" mode="side" opened="false"></mat-drawer>
+          <mat-drawer #drawer class="drawer" mode="side" opened="false"></mat-drawer>
 
-        <!--module & resources left canvas header-->
-        <div class="mc-card-header">
-          <div class="mc-card-icon">
-            <mat-icon>menu_book</mat-icon>
-          </div>
-          <div class="mc-card-meta">
-            <span class="mc-card-title" matTooltip="{{courseData?.name}}">
-              {{courseData?.name | slice:0:28}}
-            </span>
-            <span class="mc-card-sub">Duration: {{mainCourseDuration !== '' ? mainCourseDuration : '0h 0m 0s'}}</span>
-          </div>
-          <button class="mc-download-all" type="button"
-            *ngIf="resourceDownloadSvc.hasDownloadableResources(courseData)"
-            (click)="downloadAllResources($event)"
-            i18n-matTooltip matTooltip="Download all resources (.zip)" aria-label="Download all resources">
-            <mat-icon>cloud_download</mat-icon>
-          </button>
-        </div>
-        <div class="left-navbar-block">
-          <!--module & resource left footer-->
-          <div class="left-nav-bar">
-            <div class="model-button" *ngIf="!isSelfAssessment">
-              <button [disabled]="hideModule" mat-raised-button
-                class="ws-mat-primary-background mat-button-base save-btn-bottom mc-add-btn" (click)="addModule()">Add Module</button>
-              <span class="or-txt">Or</span>
-              <button [disabled]="hideResource" mat-stroked-button
-                class="add-resource-btn mat-button-base" (click)="addIndependentResource()">Add Resource</button>
+          <!--module & resources left canvas header-->
+          <div class="mc-card-header">
+            <div class="mc-card-icon">
+              <mat-icon>menu_book</mat-icon>
             </div>
-
+            <div class="mc-card-meta">
+              <span class="mc-card-title" matTooltip="{{ courseData?.name }}">
+                {{ courseData?.name | slice: 0 : 28 }}
+              </span>
+              <span class="mc-card-sub">Duration: {{ mainCourseDuration !== '' ? mainCourseDuration : '0h 0m 0s' }}</span>
+            </div>
+            <button
+              class="mc-download-all"
+              type="button"
+              *ngIf="resourceDownloadSvc.hasDownloadableResources(courseData)"
+              (click)="downloadAllResources($event)"
+              i18n-matTooltip
+              matTooltip="Download all resources (.zip)"
+              aria-label="Download all resources"
+            >
+              <mat-icon>cloud_download</mat-icon>
+            </button>
           </div>
-          <div *ngIf="!isSelfAssessment" style="width: 324px;" class="model-left-create-content div-1" cdkDropList
-            (cdkDropListDropped)="drop($event)">
-            <div class="module-container" *ngFor="let module of courseData?.children;index as i; trackBy: trackByIdentifier">
-              <div>
-                <div (click)="editContent(module)" class="left-block-container main"
-                  *ngIf="module.primaryCategory === 'Course Unit'"
-                  [ngClass]="editItem === module.identifier ? 'edit-item' : ''"
-                  (cdkDragStarted)="dragDrop(module,module.identifier, 'Module')" style="cursor: pointer;"
-                  (cdkDragReleased)="dragEnd($event)" cdkDrag cdkDragLockAxis="y">
-                  <img *ngIf="editItem !== module.identifier" src="cbp-assets/icons/Vector.svg" alt="dragDrop"
-                    class="dragIcon" />
-                  <img *ngIf="editItem === module.identifier" src="cbp-assets/icons/Vector_white.svg" alt="dragDrop"
-                    class="dragIcon" />
-                  <div class="mod-heading">
-                    <h2 class="module-text" style="margin: 0px !important">{{module.name !== '' ?
-                      module.name : "no title1"}}
-                    </h2>
-                    <span fxFlex style="flex: 1 1 auto;"></span>
-                  </div>
-                  <div *ngIf="editItem !== module.identifier" class="hide-resource">
-                    <svg (click)="toggleChildren(module)" xmlns="http://www.w3.org/2000/svg" width="11" height="7"
-                      viewBox="0 0 11 7" fill="none">
-                      <path
-                        d="M5.5 7L0 0.0852527L1.00916 -4.80825e-07L5.5 4.82935L10.9908 -4.80825e-07L12 0.0852527L5.5 7Z"
-                        fill="black" />
-                    </svg>
+          <div class="left-navbar-block">
+            <!--module & resource left footer-->
+            <div class="left-nav-bar">
+              <div class="model-button" *ngIf="!isSelfAssessment">
+                <button
+                  [disabled]="hideModule"
+                  mat-raised-button
+                  class="ws-mat-primary-background mat-button-base save-btn-bottom mc-add-btn"
+                  (click)="addModule()"
+                >
+                  Add Module
+                </button>
+                <span class="or-txt">Or</span>
+                <button
+                  [disabled]="hideResource"
+                  mat-stroked-button
+                  class="add-resource-btn mat-button-base"
+                  (click)="addIndependentResource()"
+                >
+                  Add Resource
+                </button>
+              </div>
+            </div>
+            <div
+              *ngIf="!isSelfAssessment"
+              style="width: 324px"
+              class="model-left-create-content div-1"
+              cdkDropList
+              (cdkDropListDropped)="drop($event)"
+            >
+              <div class="module-container" *ngFor="let module of courseData?.children; index as i; trackBy: trackByIdentifier">
+                <div>
+                  <div
+                    (click)="editContent(module)"
+                    class="left-block-container main"
+                    *ngIf="module.primaryCategory === 'Course Unit'"
+                    [ngClass]="editItem === module.identifier ? 'edit-item' : ''"
+                    (cdkDragStarted)="dragDrop(module, module.identifier, 'Module')"
+                    style="cursor: pointer"
+                    (cdkDragReleased)="dragEnd($event)"
+                    cdkDrag
+                    cdkDragLockAxis="y"
+                  >
+                    <img *ngIf="editItem !== module.identifier" src="cbp-assets/icons/Vector.svg" alt="dragDrop" class="dragIcon" />
+                    <img *ngIf="editItem === module.identifier" src="cbp-assets/icons/Vector_white.svg" alt="dragDrop" class="dragIcon" />
+                    <div class="mod-heading">
+                      <h2 class="module-text" style="margin: 0px !important">{{ module.name !== '' ? module.name : 'no title1' }}</h2>
+                      <span fxFlex style="flex: 1 1 auto"></span>
+                    </div>
+                    <div *ngIf="editItem !== module.identifier" class="hide-resource">
+                      <svg
+                        (click)="toggleChildren(module)"
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="11"
+                        height="7"
+                        viewBox="0 0 11 7"
+                        fill="none"
+                      >
+                        <path
+                          d="M5.5 7L0 0.0852527L1.00916 -4.80825e-07L5.5 4.82935L10.9908 -4.80825e-07L12 0.0852527L5.5 7Z"
+                          fill="black"
+                        />
+                      </svg>
 
-                    <!-- <svg (click)="toggleChildren(module)" xmlns="http://www.w3.org/2000/svg" width="11" height="7"
+                      <!-- <svg (click)="toggleChildren(module)" xmlns="http://www.w3.org/2000/svg" width="11" height="7"
                       viewBox="0 0 11 7" fill="none">
                       <path
                         d="M5.5 -4.80825e-07L11 5.91475L9.99084 7L5.5 2.17065L1.00916 7L9.4876e-08 5.91474L5.5 -4.80825e-07Z"
                         fill="black" />
                     </svg> -->
+                    </div>
+                    <div *ngIf="editItem == module.identifier" class="show-resource">
+                      <a (click)="toggleChildren(module, i)">
+                        <svg
+                          *ngIf="!showChildrenMap[module.identifier]"
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="11"
+                          height="7"
+                          viewBox="0 0 11 7"
+                          fill="none"
+                        >
+                          <path
+                            d="M5.5 -4.80825e-07L11 5.91475L9.99084 7L5.5 2.17065L1.00916 7L9.4876e-08 5.91474L5.5 -4.80825e-07Z"
+                            fill="black"
+                          />
+                        </svg>
+                        <svg
+                          *ngIf="showChildrenMap[module.identifier]"
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="11"
+                          height="7"
+                          viewBox="0 0 11 7"
+                          fill="none"
+                        >
+                          <path
+                            d="M5.5 7L0 0.0852527L1.00916 -4.80825e-07L5.5 4.82935L10.9908 -4.80825e-07L12 0.0852527L5.5 7Z"
+                            fill="black"
+                          />
+                        </svg>
+                      </a>
+                    </div>
                   </div>
-                  <div *ngIf="editItem == module.identifier" class="show-resource">
-                    <a (click)="toggleChildren(module, i)">
-                      <svg *ngIf="!showChildrenMap[module.identifier]" xmlns="http://www.w3.org/2000/svg" width="11"
-                        height="7" viewBox="0 0 11 7" fill="none">
-                        <path
-                          d="M5.5 -4.80825e-07L11 5.91475L9.99084 7L5.5 2.17065L1.00916 7L9.4876e-08 5.91474L5.5 -4.80825e-07Z"
-                          fill="black" />
-                      </svg>
-                      <svg *ngIf="showChildrenMap[module.identifier]" xmlns="http://www.w3.org/2000/svg" width="11"
-                        height="7" viewBox="0 0 11 7" fill="none">
-                        <path
-                          d="M5.5 7L0 0.0852527L1.00916 -4.80825e-07L5.5 4.82935L10.9908 -4.80825e-07L12 0.0852527L5.5 7Z"
-                          fill="black" />
-                      </svg>
-                    </a>
-                  </div>
-                </div>
 
-                <div class="children" *ngIf="module?.children?.length > 0&&showChildrenMap[module.identifier]">
-                  <div (click)=" editContent(resource)" *ngFor="let resource of module.children;index as l; trackBy: trackByIdentifier"
-                    class="resource-1" style="cursor:pointer"
-                    [ngClass]="editItem === resource.identifier ? 'edit-item' : ''" matTooltip="dragDrop"
-                    [matTooltipPosition]="'left'"
-                    (cdkDragStarted)="dragDrop(resource,resource.identifier, 'resourceInsideModule')"
-                    style="cursor: pointer;" (cdkDragReleased)="dragEnd($event)" cdkDrag cdkDragLockAxis="y">
+                  <div class="children" *ngIf="module?.children?.length > 0 && showChildrenMap[module.identifier]">
+                    <div
+                      (click)="editContent(resource)"
+                      *ngFor="let resource of module.children; index as l; trackBy: trackByIdentifier"
+                      class="resource-1"
+                      style="cursor: pointer"
+                      [ngClass]="editItem === resource.identifier ? 'edit-item' : ''"
+                      matTooltip="dragDrop"
+                      [matTooltipPosition]="'left'"
+                      (cdkDragStarted)="dragDrop(resource, resource.identifier, 'resourceInsideModule')"
+                      style="cursor: pointer"
+                      (cdkDragReleased)="dragEnd($event)"
+                      cdkDrag
+                      cdkDragLockAxis="y"
+                    >
+                      <div class="drag-icon-block">
+                        <img *ngIf="editItem !== resource.identifier" src="cbp-assets/icons/Vector.svg" alt="dragDrop" class="dragIcon" />
+                        <img
+                          *ngIf="editItem === resource.identifier"
+                          src="cbp-assets/icons/Vector_white.svg"
+                          alt="dragDrop"
+                          class="dragIcon"
+                        />
+                      </div>
+                      <div class="resource-block">
+                        <div class="resource-block-display">
+                          <span style="white-space: normal" class="resourse-text">{{ resource.name }} </span>
+                          <span *ngIf="resource.duration > 0" class="resource-duration-txt"
+                            >( {{ resource.duration | formatDuration }} )</span
+                          >
+                        </div>
+                        <div class="resource-status-block">
+                          <span *ngIf="resource.artifactUrl && resource.mimeType !== 'application/json'" class="resourse-status"
+                            >{{ resource.mimeType | MimeTypePipe }}
+                            Updated
+                          </span>
+                          <span *ngIf="resource.artifactUrl && resource.mimeType == 'application/json'" class="resourse-status"
+                            >{{ resource?.isAssessment ? 'Assessment' : 'Quiz' }}
+                            Updated
+                          </span>
+
+                          <span *ngIf="!resource.artifactUrl" class="resourse-status">Draft </span>
+                        </div>
+                      </div>
+                      <button
+                        class="resource-dl-btn"
+                        type="button"
+                        *ngIf="resource.artifactUrl || resource.downloadUrl"
+                        (click)="downloadOneResource(resource, $event)"
+                        i18n-matTooltip
+                        matTooltip="Download resource"
+                        aria-label="Download resource"
+                      >
+                        <mat-icon>cloud_download</mat-icon>
+                      </button>
+                    </div>
+                  </div>
+                  <button
+                    class="children"
+                    [disabled]="hideResource"
+                    *ngIf="module.primaryCategory === 'Course Unit' && showChildrenMap[module.identifier]"
+                    mat-raised-button
+                    class="secondary-button-outline mat-button-base addResourceBtn"
+                    (click)="addResModule(module.identifier, courseData.identifier)"
+                  >
+                    Add Resource
+                  </button>
+                  <div
+                    (click)="editContent(module)"
+                    *ngIf="module.primaryCategory !== 'Course Unit'"
+                    class="heading-resource resource-2"
+                    [ngClass]="editItem === module.identifier ? 'edit-item' : ''"
+                    matTooltip="dragDrop"
+                    (cdkDragStarted)="dragDrop(module, module.identifier, 'resource')"
+                    style="cursor: pointer"
+                    (cdkDragReleased)="dragEnd($event)"
+                    cdkDrag
+                    cdkDragLockAxis="y"
+                  >
                     <div class="drag-icon-block">
-                      <img *ngIf="editItem !== resource.identifier" src="cbp-assets/icons/Vector.svg" alt="dragDrop"
-                        class="dragIcon" />
-                      <img *ngIf="editItem === resource.identifier" src="cbp-assets/icons/Vector_white.svg"
-                        alt="dragDrop" class="dragIcon" />
+                      <img
+                        *ngIf="editItem !== module.identifier"
+                        loading="lazy"
+                        src="cbp-assets/icons/Vector.svg"
+                        alt="dragDrop"
+                        class="dragIcon"
+                      />
+                      <img
+                        *ngIf="editItem === module.identifier"
+                        loading="lazy"
+                        src="cbp-assets/icons/Vector_white.svg"
+                        alt="dragDrop"
+                        class="dragIcon"
+                      />
                     </div>
                     <div class="resource-block">
                       <div class="resource-block-display">
-                        <span style="white-space: normal;" class="resourse-text">{{resource.name}} </span>
-                        <span *ngIf="resource.duration>0" class="resource-duration-txt">(
-                          {{ resource.duration | formatDuration }} )</span>
+                        <span title="{{ module.name }}" class="resourse-text" style="white-space: normal">{{ module.name }}</span>
+                        <span *ngIf="module.duration > 0" class="resource-duration-txt">( {{ module.duration | formatDuration }} )</span>
                       </div>
                       <div class="resource-status-block">
-                        <span *ngIf="resource.artifactUrl&& resource.mimeType !== 'application/json'"
-                          class="resourse-status">{{resource.mimeType |
-                          MimeTypePipe}}
+                        <span *ngIf="module.artifactUrl && module.mimeType !== 'application/json'" class="resourse-status"
+                          >{{ module.mimeType | MimeTypePipe }}
                           Updated
                         </span>
-                        <span *ngIf="resource.artifactUrl&& resource.mimeType == 'application/json'"
-                          class="resourse-status">{{resource?.isAssessment?'Assessment':'Quiz'}}
+                        <span *ngIf="module.artifactUrl && module.mimeType == 'application/json'" class="resourse-status"
+                          >{{ module?.isAssessment ? 'Assessment' : 'Quiz' }}
                           Updated
                         </span>
-
-                        <span *ngIf="!resource.artifactUrl" class="resourse-status">Draft
-                        </span>
+                        <span *ngIf="!module.artifactUrl" class="resourse-status">Draft </span>
                       </div>
                     </div>
-                    <button class="resource-dl-btn" type="button"
-                      *ngIf="resource.artifactUrl || resource.downloadUrl"
-                      (click)="downloadOneResource(resource, $event)"
-                      i18n-matTooltip matTooltip="Download resource" aria-label="Download resource">
+                    <button
+                      class="resource-dl-btn"
+                      type="button"
+                      *ngIf="module.artifactUrl || module.downloadUrl"
+                      (click)="downloadOneResource(module, $event)"
+                      i18n-matTooltip
+                      matTooltip="Download resource"
+                      aria-label="Download resource"
+                    >
                       <mat-icon>cloud_download</mat-icon>
                     </button>
                   </div>
                 </div>
-                <button class="children" [disabled]="hideResource"
-                  *ngIf="module.primaryCategory === 'Course Unit'&& showChildrenMap[module.identifier]"
-                  mat-raised-button class=" secondary-button-outline mat-button-base addResourceBtn"
-                  (click)="addResModule(module.identifier, courseData.identifier)">Add Resource</button>
-                <div (click)="editContent(module)" *ngIf="module.primaryCategory !== 'Course Unit'"
-                  class="heading-resource resource-2" [ngClass]="editItem === module.identifier ? 'edit-item' : ''"
-                  matTooltip="dragDrop" (cdkDragStarted)="dragDrop(module,module.identifier, 'resource')"
-                  style="cursor: pointer;" (cdkDragReleased)="dragEnd($event)" cdkDrag cdkDragLockAxis="y">
-                  <div class="drag-icon-block">
-                    <img *ngIf="editItem !== module.identifier" loading="lazy" src="cbp-assets/icons/Vector.svg"
-                      alt="dragDrop" class="dragIcon" />
-                    <img *ngIf="editItem === module.identifier" loading="lazy" src="cbp-assets/icons/Vector_white.svg"
-                      alt="dragDrop" class="dragIcon" />
+              </div>
+              <!--module & resources left canvas-->
+              <div class="model-text" cdkDropList (cdkDropListDropped)="drop($event)">
+                <span *ngIf="courseData?.children.length === 0"
+                  >Your Modules and Resources will be visible here once you start adding them.</span
+                >
+              </div>
+              <!-- <ws-author-auth-toc></ws-author-auth-toc> -->
+              <!--module left canvas creation-->
+              <div
+                class="model-left-create-content div-2"
+                *ngIf="showAddModuleForm && moduleNames.length > 0"
+                cdkDropList
+                (cdkDropListDropped)="drop($event)"
+              >
+                <div (click)="editContent(module)" class="module-container" *ngFor="let module of moduleNames; trackBy: trackByIdentifier">
+                  <div class="mod-heading">
+                    <h2 class="module-text" style="margin: 0px !important">
+                      {{
+                        module.name !== ''
+                          ? module.name
+                          : 'no
+                    title2'
+                      }}
+                    </h2>
+                    <span fxFlex style="flex: 1 1 auto"></span>
                   </div>
-                  <div class="resource-block">
-                    <div class="resource-block-display">
-                      <span title="{{module.name}}" class="resourse-text" style="white-space: normal;">{{
-                        module.name}}</span>
-                      <span *ngIf="module.duration>0" class="resource-duration-txt">(
-                        {{ module.duration | formatDuration }} )</span>
-                    </div>
-                    <div class="resource-status-block">
-                      <span *ngIf="module.artifactUrl&& module.mimeType !== 'application/json'"
-                        class="resourse-status">{{module.mimeType | MimeTypePipe}}
-                        Updated
-                      </span>
-                      <span *ngIf="module.artifactUrl&& module.mimeType == 'application/json'"
-                        class="resourse-status">{{module?.isAssessment?'Assessment':'Quiz'}}
-                        Updated
-                      </span>
-                      <span *ngIf="!module.artifactUrl" class="resourse-status">Draft
-                      </span>
+                  <div *ngIf="isOnClickOfResourceTypeEnabled">
+                    <div
+                      (click)="editContent(resource)"
+                      *ngFor="let resource of resourceNames; trackBy: trackByIdentifier"
+                      class="heading-resource resource-3"
+                    >
+                      <div class="custom-placeholder border border-solid" *cdkDragPlaceholder></div>
+                      <mat-icon
+                        class="cursor-pointer"
+                        matTooltip="dragDrop"
+                        [matTooltipPosition]="'left'"
+                        cdkDrag
+                        cdkDragBoundary=".model-left-create-content div-3"
+                        cdkDragLockAxis="y"
+                        (click)="dragDrop(resource, resource.identifier, 'resource')"
+                        >none</mat-icon
+                      >
+                      <span class="resourse-text" style="white-space: normal">{{ resource.name }}</span>
+                      <span fxFlex style="flex: 1 1 auto"></span>
                     </div>
                   </div>
-                  <button class="resource-dl-btn" type="button"
-                    *ngIf="module.artifactUrl || module.downloadUrl"
-                    (click)="downloadOneResource(module, $event)"
-                    i18n-matTooltip matTooltip="Download resource" aria-label="Download resource">
-                    <mat-icon>cloud_download</mat-icon>
+
+                  <button
+                    *ngIf="isSaveModuleFormEnable"
+                    mat-raised-button
+                    [disabled]="!isOnClickOfResourceTypeEnabled"
+                    class="button-style secondary-button-outline mat-button-base"
+                    style="margin: 0.4rem; color: #1c5d95 !important"
+                    (click)="addIndependentResource()"
+                  >
+                    Add Resource
                   </button>
                 </div>
               </div>
             </div>
-            <!--module & resources left canvas-->
-            <div class="model-text" cdkDropList (cdkDropListDropped)="drop($event)">
-              <span *ngIf="courseData?.children.length===0">Your Modules and Resources will be visible here once you start adding them.</span>
-            </div>
-            <!-- <ws-author-auth-toc></ws-author-auth-toc> -->
-            <!--module left canvas creation-->
-            <div class="model-left-create-content div-2" *ngIf="showAddModuleForm && moduleNames.length >0" cdkDropList
-              (cdkDropListDropped)="drop($event)">
-              <div (click)="editContent(module)" class="module-container" *ngFor="let module of moduleNames; trackBy: trackByIdentifier">
-                <div class="mod-heading">
-                  <h2 class="module-text" style="margin: 0px !important;">{{module.name !== '' ? module.name : "no
-                    title2"}}
-                  </h2>
-                  <span fxFlex style="flex: 1 1 auto;"></span>
-                </div>
-                <div *ngIf="isOnClickOfResourceTypeEnabled">
-                  <div (click)="editContent(resource)" *ngFor="let resource of resourceNames; trackBy: trackByIdentifier"
-                    class="heading-resource resource-3">
-                    <div class="custom-placeholder border border-solid" *cdkDragPlaceholder></div>
-                    <mat-icon class="cursor-pointer" matTooltip="dragDrop" [matTooltipPosition]="'left'" cdkDrag
-                      cdkDragBoundary=".model-left-create-content div-3" cdkDragLockAxis="y"
-                      (click)="dragDrop(resource,resource.identifier, 'resource')">none</mat-icon> <span
-                      class="resourse-text" style="white-space: normal;">{{resource.name}}</span>
-                    <span fxFlex style="flex: 1 1 auto;"></span>
+            <div *ngIf="isSelfAssessment" class="model-left-create-content div-1 sa-level-list">
+              <div class="module-container" *ngFor="let module of courseData?.children; index as i; trackBy: trackByIdentifier">
+                <div>
+                  <div
+                    (click)="editContent(module)"
+                    class="left-block-container"
+                    *ngIf="module.primaryCategory === 'Course Unit'"
+                    [ngClass]="editItem === module.identifier ? 'edit-item' : ''"
+                    style="cursor: pointer"
+                  >
+                    <img *ngIf="editItem !== module.identifier" src="cbp-assets/icons/Vector.svg" alt="dragDrop" class="dragIcon" />
+                    <img *ngIf="editItem === module.identifier" src="cbp-assets/icons/Vector_white.svg" alt="dragDrop" class="dragIcon" />
+                    <div class="mod-heading">
+                      <h2 class="module-text" style="margin: 0px !important">{{ module.name !== '' ? module.name : 'no title1' }}</h2>
+                      <span fxFlex style="flex: 1 1 auto"></span>
+                    </div>
+                  </div>
+                  <div *ngIf="module?.children?.length > 0">
+                    <div
+                      (click)="editContent(resource)"
+                      *ngFor="let resource of module.children; index as l; trackBy: trackByIdentifier"
+                      class="resource-1"
+                      style="cursor: pointer"
+                      [ngClass]="editItem === resource.identifier ? 'edit-item' : ''"
+                      style="cursor: pointer"
+                    >
+                      <img *ngIf="editItem !== resource.identifier" src="cbp-assets/icons/Vector.svg" alt="dragDrop" class="dragIcon" />
+                      <img
+                        *ngIf="editItem === resource.identifier"
+                        src="cbp-assets/icons/Vector_white.svg"
+                        alt="dragDrop"
+                        class="dragIcon"
+                      />
+                      <span *ngIf="resource.mimeType == 'application/json'" style="white-space: normal" class="resourse-text"
+                        >{{ resource.name }}
+                      </span>
+                      <span *ngIf="resource.duration > 0" class="resource-duration-txt">( {{ resource.duration | formatDuration }} )</span>
+                    </div>
+                  </div>
+                  <div
+                    (click)="editContent(module)"
+                    *ngIf="module.primaryCategory !== 'Course Unit'"
+                    class="heading-resource resource-2"
+                    [ngClass]="editItem === module.identifier ? 'edit-item' : ''"
+                    style="cursor: pointer"
+                  >
+                    <img
+                      *ngIf="editItem !== module.identifier"
+                      loading="lazy"
+                      src="cbp-assets/icons/Vector.svg"
+                      alt="dragDrop"
+                      class="dragIcon"
+                    />
+                    <img
+                      *ngIf="editItem === module.identifier"
+                      loading="lazy"
+                      src="cbp-assets/icons/Vector_white.svg"
+                      alt="dragDrop"
+                      class="dragIcon"
+                    />
+                    <span
+                      *ngIf="module.mimeType == 'application/json'"
+                      title="{{ module.name }}"
+                      class="resourse-text"
+                      style="white-space: normal"
+                      >{{ module.name }}</span
+                    >
+                    <span *ngIf="module.duration > 0" class="resource-duration-txt">( {{ module.duration | formatDuration }} )</span>
                   </div>
                 </div>
-
-                <button *ngIf="isSaveModuleFormEnable" mat-raised-button [disabled]="!isOnClickOfResourceTypeEnabled"
-                  class="button-style secondary-button-outline mat-button-base "
-                  style="margin:0.4rem;color: #1C5D95 !important;" (click)="addIndependentResource()"> Add
-                  Resource</button>
-
-              </div>
-            </div>
-          </div>
-          <div *ngIf="isSelfAssessment" class="model-left-create-content div-1 sa-level-list">
-            <div class="module-container" *ngFor="let module of courseData?.children;index as i; trackBy: trackByIdentifier">
-              <div>
-                <div (click)="editContent(module)" class="left-block-container"
+                <button
+                  [disabled]="hideResource"
                   *ngIf="module.primaryCategory === 'Course Unit'"
-                  [ngClass]="editItem === module.identifier ? 'edit-item' : ''" style="cursor: pointer;">
-                  <img *ngIf="editItem !== module.identifier" src="cbp-assets/icons/Vector.svg" alt="dragDrop"
-                    class="dragIcon" />
-                  <img *ngIf="editItem === module.identifier" src="cbp-assets/icons/Vector_white.svg" alt="dragDrop"
-                    class="dragIcon" />
-                  <div class="mod-heading">
-                    <h2 class="module-text" style="margin: 0px !important">{{module.name !== '' ?
-                      module.name : "no title1"}}
-                    </h2>
-                    <span fxFlex style="flex: 1 1 auto;"></span>
-                  </div>
-                </div>
-                <div *ngIf="module?.children?.length > 0">
-                  <div (click)="editContent(resource)" *ngFor="let resource of module.children;index as l; trackBy: trackByIdentifier"
-                    class="resource-1" style="cursor:pointer"
-                    [ngClass]="editItem === resource.identifier ? 'edit-item' : ''" style="cursor: pointer;">
-                    <img *ngIf="editItem !== resource.identifier" src="cbp-assets/icons/Vector.svg" alt="dragDrop"
-                      class="dragIcon" />
-                    <img *ngIf="editItem === resource.identifier" src="cbp-assets/icons/Vector_white.svg" alt="dragDrop"
-                      class="dragIcon" />
-                    <span *ngIf="resource.mimeType=='application/json'" style="white-space: normal;"
-                      class="resourse-text">{{resource.name}}
-                    </span>
-                    <span *ngIf="resource.duration>0" class="resource-duration-txt">(
-                      {{ resource.duration | formatDuration }} )</span>
-                  </div>
-                </div>
-                <div (click)="editContent(module)" *ngIf="module.primaryCategory !== 'Course Unit'"
-                  class="heading-resource resource-2" [ngClass]="editItem === module.identifier ? 'edit-item' : ''"
-                  style="cursor: pointer;">
-                  <img *ngIf="editItem !== module.identifier" loading="lazy" src="cbp-assets/icons/Vector.svg"
-                    alt="dragDrop" class="dragIcon" />
-                  <img *ngIf="editItem === module.identifier" loading="lazy" src="cbp-assets/icons/Vector_white.svg"
-                    alt="dragDrop" class="dragIcon" />
-                  <span *ngIf="module.mimeType=='application/json'" title="{{module.name}}" class="resourse-text"
-                    style="white-space: normal;">{{ module.name}}</span>
-                  <span *ngIf="module.duration>0" class="resource-duration-txt">(
-                    {{ module.duration | formatDuration }} )</span>
-                </div>
+                  mat-raised-button
+                  class="secondary-button-outline mat-button-base addResourceBtn"
+                  (click)="addResModule(module.identifier, courseData.identifier)"
+                >
+                  Add Resource
+                </button>
               </div>
-              <button [disabled]="hideResource" *ngIf="module.primaryCategory === 'Course Unit'" mat-raised-button
-                class="secondary-button-outline mat-button-base addResourceBtn"
-                (click)="addResModule(module.identifier, courseData.identifier)">Add Resource</button>
-            </div>
 
-            <!--module & resources left canvas-->
-            <div class="model-text" cdkDropList (cdkDropListDropped)="drop($event)">
-              <span *ngIf="courseData?.children.length===0"> Your Modules and Resources will be visible
-                here once you start adding
-                them.</span>
-            </div>
-            <!-- <ws-author-auth-toc></ws-author-auth-toc> -->
-            <!--module left canvas creation-->
-            <div class="model-left-create-content div-2" *ngIf="showAddModuleForm && moduleNames.length >0" cdkDropList
-              (cdkDropListDropped)="drop($event)">
-              <div (click)="editContent(module)" class="module-container" *ngFor="let module of moduleNames; trackBy: trackByIdentifier">
-                <div class="mod-heading">
-                  <h2 class="module-text" style="margin: 0px !important;">{{module.name !== '' ? module.name : "no
-                    title2"}}
-                  </h2>
-                  <span fxFlex style="flex: 1 1 auto;"></span>
-                </div>
-                <div *ngIf="isOnClickOfResourceTypeEnabled">
-                  <div (click)="editContent(resource)" *ngFor="let resource of resourceNames; trackBy: trackByIdentifier"
-                    class="heading-resource resource-3">
-                    <div class="custom-placeholder border border-solid" *cdkDragPlaceholder></div>
-                    <mat-icon class="cursor-pointer" matTooltip="dragDrop" [matTooltipPosition]="'left'" cdkDrag
-                      cdkDragBoundary=".model-left-create-content div-3" cdkDragLockAxis="y"
-                      (click)="dragDrop(resource,resource.identifier, 'resource')">none</mat-icon> <span
-                      class="resourse-text" style="white-space: normal;">{{resource.name}}</span>
-                    <span fxFlex style="flex: 1 1 auto;"></span>
+              <!--module & resources left canvas-->
+              <div class="model-text" cdkDropList (cdkDropListDropped)="drop($event)">
+                <span *ngIf="courseData?.children.length === 0">
+                  Your Modules and Resources will be visible here once you start adding them.</span
+                >
+              </div>
+              <!-- <ws-author-auth-toc></ws-author-auth-toc> -->
+              <!--module left canvas creation-->
+              <div
+                class="model-left-create-content div-2"
+                *ngIf="showAddModuleForm && moduleNames.length > 0"
+                cdkDropList
+                (cdkDropListDropped)="drop($event)"
+              >
+                <div (click)="editContent(module)" class="module-container" *ngFor="let module of moduleNames; trackBy: trackByIdentifier">
+                  <div class="mod-heading">
+                    <h2 class="module-text" style="margin: 0px !important">
+                      {{
+                        module.name !== ''
+                          ? module.name
+                          : 'no
+                    title2'
+                      }}
+                    </h2>
+                    <span fxFlex style="flex: 1 1 auto"></span>
                   </div>
+                  <div *ngIf="isOnClickOfResourceTypeEnabled">
+                    <div
+                      (click)="editContent(resource)"
+                      *ngFor="let resource of resourceNames; trackBy: trackByIdentifier"
+                      class="heading-resource resource-3"
+                    >
+                      <div class="custom-placeholder border border-solid" *cdkDragPlaceholder></div>
+                      <mat-icon
+                        class="cursor-pointer"
+                        matTooltip="dragDrop"
+                        [matTooltipPosition]="'left'"
+                        cdkDrag
+                        cdkDragBoundary=".model-left-create-content div-3"
+                        cdkDragLockAxis="y"
+                        (click)="dragDrop(resource, resource.identifier, 'resource')"
+                        >none</mat-icon
+                      >
+                      <span class="resourse-text" style="white-space: normal">{{ resource.name }}</span>
+                      <span fxFlex style="flex: 1 1 auto"></span>
+                    </div>
+                  </div>
+
+                  <button
+                    *ngIf="isSaveModuleFormEnable"
+                    mat-raised-button
+                    [disabled]="!isOnClickOfResourceTypeEnabled"
+                    class="button-style secondary-button-outline mat-button-base"
+                    style="margin: 0.4rem; color: #1c5d95 !important"
+                    (click)="addIndependentResource()"
+                  >
+                    Add Resource
+                  </button>
                 </div>
-
-                <button *ngIf="isSaveModuleFormEnable" mat-raised-button [disabled]="!isOnClickOfResourceTypeEnabled"
-                  class="button-style secondary-button-outline mat-button-base "
-                  style="margin:0.4rem;color: #1C5D95 !important;" (click)="addIndependentResource()"> Add
-                  Resource</button>
-
               </div>
             </div>
           </div>
-        </div>
-
-
-      </mat-drawer-container>
-      </div><!-- /mc-left-col -->
+        </mat-drawer-container>
+      </div>
+      <!-- /mc-left-col -->
       <div class="mc-right-col">
         <mat-drawer-container [class.drawer-opened]="drawer.opened" class="example-container">
-        <!--module right canvas header-->
-        <div class="mc-card-header mc-right-header">
-          <div class="mc-card-icon">
-            <mat-icon>{{isSelfAssessment ? 'assignment' : 'account_tree'}}</mat-icon>
+          <!--module right canvas header-->
+          <div class="mc-card-header mc-right-header">
+            <div class="mc-card-icon">
+              <mat-icon>{{ isSelfAssessment ? 'assignment' : 'account_tree' }}</mat-icon>
+            </div>
+            <div class="mc-card-meta">
+              <span class="mc-card-title">{{ isSelfAssessment ? 'Self Assessment Builder' : 'Course Builder' }}</span>
+              <span class="mc-card-sub" *ngIf="!isSelfAssessment">Add modules and resources to structure your course</span>
+            </div>
+            <button
+              mat-stroked-button
+              class="preview-btn mc-preview-btn"
+              [routerLink]="'/author/toc/' + courseData?.identifier + '/contents'"
+            >
+              <mat-icon>remove_red_eye</mat-icon>
+              Preview
+            </button>
           </div>
-          <div class="mc-card-meta">
-            <span class="mc-card-title">{{isSelfAssessment ? 'Self Assessment Builder' : 'Course Builder'}}</span>
-            <span class="mc-card-sub" *ngIf="!isSelfAssessment">Add modules and resources to structure your course</span>
+          <!--module & resource right canvas create page-->
+          <div class="landing-right-content" *ngIf="!showAddModuleForm && !isSelfAssessment">
+            <div class="course-title-block">
+              <span class="course-title">Start by adding Modules and Resources to build the Course</span>
+              <p class="empty-state-helper-text">
+                Use <strong>Add Module</strong> to group related content, or <strong>Add Resource</strong> to add a PDF, video, link, or
+                other content directly to the course.
+              </p>
+            </div>
+            <div class="image-container">
+              <img loading="lazy" class="course-builder-bg" src="cbp-assets/images/course-builder-bg.svg" alt="Image" />
+            </div>
           </div>
-          <button mat-stroked-button class="preview-btn mc-preview-btn"
-            [routerLink]="'/author/toc/' + courseData?.identifier + '/contents'">
-            <mat-icon>remove_red_eye</mat-icon>
-            Preview
-          </button>
-        </div>
-        <!--module & resource right canvas create page-->
-        <div class="landing-right-content" *ngIf="!showAddModuleForm&&!isSelfAssessment">
-          <div class="course-title-block">
-            <span class="course-title">Start by adding Modules and Resources to build the Course</span>
-            <p class="empty-state-helper-text">Use <strong>Add Module</strong> to group related content, or <strong>Add Resource</strong> to add a PDF, video, link, or other content directly to the course.</p>
+          <div class="self-landing-right-content" *ngIf="!showAddModuleForm && isSelfAssessment">
+            <div class="course-title-block">
+              <span class="course-title">Start by adding questions to each assessment level</span>
+              <p class="empty-state-helper-text">Select an assessment level from the left panel to begin adding questions.</p>
+            </div>
+            <div class="image-container">
+              <img loading="lazy" class="course-builder-bg" src="cbp-assets/images/selfAssessmentBackground.svg" alt="Image" />
+            </div>
           </div>
-          <div class="image-container">
-            <img loading="lazy" class="course-builder-bg" src="cbp-assets/images/course-builder-bg.svg" alt="Image">
-          </div>
-        </div>
-        <div class="self-landing-right-content" *ngIf="!showAddModuleForm&&isSelfAssessment">
-          <div class="course-title-block">
-            <span class="course-title">Start by adding questions to each assessment level</span>
-            <p class="empty-state-helper-text">Select an assessment level from the left panel to begin adding questions.</p>
-          </div>
-          <div class="image-container">
-            <img loading="lazy" class="course-builder-bg" src="cbp-assets/images/selfAssessmentBackground.svg"
-              alt="Image">
-          </div>
-        </div>
 
-
-        <!--module right canvas right create page-->
-        <div class="module-right-content scroll-bar"
-          *ngIf="showAddModuleForm && !isResourceTypeEnabled && !isOnClickOfResourceTypeEnabled">
-          <div class="module-resource-title-block">
-            <div>
-              <span class="course-sub-title"
-                *ngIf="!isSaveModuleFormEnable&&content?.contentType !== 'Collection'">Create Course</span>
-              <span class="course-sub-title" *ngIf="content?.contentType === 'Course'">Course Details</span>
-              <span class="course-sub-title" *ngIf="content?.contentType === 'CourseUnit'">Module Details</span>
-              <span class="course-sub-title" *ngIf="content?.contentType === 'Collection'">Module Details</span>
-              <span class="course-sub-title" *ngIf="content?.contentType === 'Resource'&&!isSelfAssessment">Resource
-                Details</span>
-              <span class="course-sub-title" *ngIf="isSelfAssessment">Assessment Details : </span>
-              <span style="color: #1C5D95;" *ngIf="isSelfAssessment" class="course-sub-title">Level
-                {{content.index}}</span>
-            </div>
-            <div class="save-btn-block" *ngIf="!isSelfAssessment">
-              <button mat-icon-button class="mc-delete-icon-btn" (click)="takeActions('delete', content, $event.type)"
-                matTooltip="Delete">
-                <mat-icon>delete_outline</mat-icon>
-              </button>
-              <button mat-raised-button *ngIf="moduleButtonName === 'Create' && content?.contentType !== 'Course'"
-                class="width-15 text-white   mat-button-base save-btn-bottom"
-                (click)="moduleCreate(moduleName, topicDescription, thumbnail)">
-                {{moduleButtonName}}</button>
-              <button mat-raised-button
-                *ngIf="content?.contentType === 'CourseUnit'||content?.contentType === 'Collection'"
-                class="width-15 text-white   mat-button-base save-btn-bottom resourcePdfSave"
-                (click)="saveDetails(moduleName, topicDescription, thumbnail, isNewTab,isShowBtn,content?.mimeType)">
-                {{moduleButtonName}}</button>
-              <button [disabled]="(uploadFileName?uploadFileName == '':true)" mat-raised-button
-                *ngIf="moduleButtonName === 'Save'&&content?.contentType !== 'Collection' && content?.contentType !== 'CourseUnit' && content?.contentType !== 'Course'&& !isLinkEnabled && content?.mimeType !== 'application/json'"
-                class="width-15 text-white   mat-button-base save-btn-bottom resourcePdfSave"
-                (click)="saveDetails(moduleName, topicDescription, thumbnail, isNewTab,isShowBtn,content?.mimeType)">
-                {{moduleButtonName}}</button>
-              <button [disabled]="isLinkEnabled?editResourceLinks.length==0:true || moduleName == ''" mat-raised-button
-                *ngIf="moduleButtonName === 'Save' && content?.contentType !== 'Course'&&isLinkEnabled"
-                class="width-15 text-white   mat-button-base save-btn-bottom resourcePdfSave"
-                (click)="saveDetails(moduleName, topicDescription, thumbnail, isNewTab,isShowBtn,content?.mimeType)">
-                {{moduleButtonName}}</button>
-              <button mat-raised-button
-                *ngIf="moduleButtonName === 'Save' && content?.contentType !== 'Course'&&!isLinkEnabled &&content?.mimeType === 'application/json'"
-                class="width-15 text-white   mat-button-base save-btn-bottom resourcePdfSave"
-                (click)="saveDetails(moduleName, topicDescription, thumbnail, isNewTab,isShowBtn,content?.mimeType)">
-                {{moduleButtonName}}</button>
-              <button mat-raised-button *ngIf="content?.contentType === 'Course'"
-                class="width-15 text-white   mat-button-base save-btn-bottom resourcePdfSave"
-                (click)="saveCourseDetails()">
-                Save</button>
-            </div>
-          </div>
-          <div class="module-txt-block mc-form-field-row" *ngIf="content?.contentType === 'Course'">
-            <input name="moduleName" type="text" matInput [(ngModel)]="moduleName" #module
-              class="module-input" placeholder="Name of the Course" autocomplete="off" maxlength="250" />
-            <div class="mc-field-footer">
-              <span *ngIf="moduleName == ''" class="invalid-text">This field is Required</span>
-              <mat-hint class="mt-hint">{{ moduleName.length }}/250</mat-hint>
-            </div>
-          </div>
-          <div class="module-txt-block mc-form-field-row" *ngIf="content?.contentType === 'CourseUnit' &&!isSelfAssessment">
-            <input name="moduleName" type="text" matInput [(ngModel)]="moduleName" #module
-              class="module-input" placeholder="Name of the Module" autocomplete="off" maxlength="100" />
-            <div class="mc-field-footer">
-              <span *ngIf="moduleName == ''" class="invalid-text">This field is Required</span>
-              <mat-hint class="mt-hint">{{ moduleName.length }}/100</mat-hint>
-            </div>
-          </div>
-          <div class="module-txt-block mc-form-field-row" *ngIf="content?.contentType === 'Resource'&&!isSelfAssessment">
-            <div class="mc-input-row">
-              <input name="moduleName" type="text" matInput [(ngModel)]="moduleName" #module
-                class="module-input" placeholder="Name of the Resource" autocomplete="off" maxlength="100" />
-              <button *ngIf="uploadVideoUrl && content?.mimeType === 'video/mp4'"
-                class="re-upload-btn mat-button-base"
-                (click)="deleteUploadedFile(); $event.stopPropagation()">
-                <img alt="" src="cbp-assets/icons/mage_reload.svg" style="width:16px;height:16px;"> Re-upload
-              </button>
-            </div>
-            <div class="mc-field-footer">
-              <span *ngIf="moduleName == ''" class="invalid-text">This field is Required</span>
-              <mat-hint class="mt-hint">{{ moduleName.length }}/100</mat-hint>
-            </div>
-          </div>
-          <div class="module-txt-block mc-form-field-row" *ngIf="content?.contentType === 'Collection'">
-            <input name="moduleName" type="text" matInput [(ngModel)]="moduleName" #module
-              class="module-input" placeholder="Name of the Resource" autocomplete="off" maxlength="100" />
-            <div class="mc-field-footer">
-              <span *ngIf="moduleName == ''" class="invalid-text">This field is Required</span>
-              <mat-hint class="mt-hint">{{ moduleName.length }}/100</mat-hint>
-            </div>
-          </div>
-          <div class="module-txt-block margin-top-l" *ngIf="isSelfAssessment">
-            <span class="self-assessment-name">{{moduleName}}</span>
-          </div>
-          <div class="module-txt-block" *ngIf="content?.mimeType === 'application/json'&&!isSelfAssessment">
-            <ng-container *ngTemplateOutlet="assessmentWarningTpl"></ng-container>
-          </div>
-          <!-- is link enabled -->
-          <div class="module-txt-block" *ngIf="isLinkEnabled">
-            <input #artifactUrl name="moduleName" type="text" matInput [(ngModel)]="editResourceLinks"
-              class="module-input margin-top-xs field-width" placeholder="Link" autocomplete="off" maxlength="100"
-              i18n-placeholder />
-
-          </div>
-          <div *ngIf="isLinkEnabled" class="margin-bottom-s margin-top-s module-txt-block">
-            <span style="color: #808080 !important;">Note : A link can be a URL or an Youtube embeded link</span>
-          </div>
-          <div class="module-txt-block margin-top-s" *ngIf="isLinkEnabled">
-            <span *ngIf="editResourceLinks == ''" class="invalid-text">This field is Required</span>
-          </div>
-          <!-- is pdf/video/audio/zip -->
-          <div class="module-txt-block margin-top-s"
-            *ngIf="isPdfOrAudioOrVedioEnabled&&content?.mimeType !== 'application/json'">
-
-            <!-- No file yet — upload card -->
-            <ng-container *ngIf="uploadFileName == '' && !uploadVideoUrl">
-              <div class="mc-upload-card" (click)="pdfFile.click()">
-                <input #pdfFile (change)="uploadPdf($event.target.files[0]); pdfFile.value = null"
-                  style="display: none;" accept="{{acceptType}}" type="file" />
-                <!-- show resource-type icon only when set, otherwise use generic upload icon -->
-                <img *ngIf="resourceImg" class="mc-upload-type-icon" [src]="resourceImg" alt="" />
-                <mat-icon *ngIf="!resourceImg" class="mc-upload-icon-fallback">upload_file</mat-icon>
-                <button mat-stroked-button class="mc-upload-btn"
-                  (click)="pdfFile.click(); $event.stopPropagation()">
-                  <mat-icon>upload</mat-icon>
-                  Upload File
-                </button>
-                <span class="mc-upload-info">Files allowed: {{uploadText || 'PDF, MP3, MP4, ZIP'}} &nbsp;·&nbsp; Max. file size: 200 MB</span>
+          <!--module right canvas right create page-->
+          <div
+            class="module-right-content scroll-bar"
+            *ngIf="showAddModuleForm && !isResourceTypeEnabled && !isOnClickOfResourceTypeEnabled"
+          >
+            <div class="module-resource-title-block">
+              <div>
+                <span class="course-sub-title" *ngIf="!isSaveModuleFormEnable && content?.contentType !== 'Collection'">Create Course</span>
+                <span class="course-sub-title" *ngIf="content?.contentType === 'Course'">Course Details</span>
+                <span class="course-sub-title" *ngIf="content?.contentType === 'CourseUnit'">Module Details</span>
+                <span class="course-sub-title" *ngIf="content?.contentType === 'Collection'">Module Details</span>
+                <span class="course-sub-title" *ngIf="content?.contentType === 'Resource' && !isSelfAssessment">Resource Details</span>
+                <span class="course-sub-title" *ngIf="isSelfAssessment">Assessment Details : </span>
+                <span style="color: #1c5d95" *ngIf="isSelfAssessment" class="course-sub-title">Level {{ content.index }}</span>
               </div>
-              <span *ngIf="acceptType == '.pdf'" class="mc-upload-note">Note: The PDF should have high resolution</span>
-            </ng-container>
-
-            <!-- File uploaded (non-video) -->
-            <div class="mc-uploaded-row" *ngIf="uploadFileName != '' && content?.mimeType !== 'video/mp4'">
-              <div class="mc-uploaded-file-card">
-                <img alt="" class="uploaded-img" src="{{uploadIcon}}" />
-                <span class="text-wrap mc-uploaded-name">{{uploadFileName}}</span>
-                <button mat-icon-button class="mc-remove-file-btn"
-                  (click)="deleteUploadedFile(); $event.stopPropagation()" matTooltip="Remove file">
-                  <mat-icon>close</mat-icon>
+              <div class="save-btn-block" *ngIf="!isSelfAssessment">
+                <button
+                  mat-icon-button
+                  class="mc-delete-icon-btn"
+                  (click)="takeActions('delete', content, $event.type)"
+                  matTooltip="Delete"
+                >
+                  <mat-icon>delete_outline</mat-icon>
+                </button>
+                <button
+                  mat-raised-button
+                  *ngIf="moduleButtonName === 'Create' && content?.contentType !== 'Course'"
+                  class="width-15 text-white mat-button-base save-btn-bottom"
+                  (click)="moduleCreate(moduleName, topicDescription, thumbnail)"
+                >
+                  {{ moduleButtonName }}
+                </button>
+                <button
+                  mat-raised-button
+                  *ngIf="content?.contentType === 'CourseUnit' || content?.contentType === 'Collection'"
+                  class="width-15 text-white mat-button-base save-btn-bottom resourcePdfSave"
+                  (click)="saveDetails(moduleName, topicDescription, thumbnail, isNewTab, isShowBtn, content?.mimeType)"
+                >
+                  {{ moduleButtonName }}
+                </button>
+                <button
+                  [disabled]="uploadFileName ? uploadFileName == '' : true"
+                  mat-raised-button
+                  *ngIf="
+                    moduleButtonName === 'Save' &&
+                    content?.contentType !== 'Collection' &&
+                    content?.contentType !== 'CourseUnit' &&
+                    content?.contentType !== 'Course' &&
+                    !isLinkEnabled &&
+                    content?.mimeType !== 'application/json'
+                  "
+                  class="width-15 text-white mat-button-base save-btn-bottom resourcePdfSave"
+                  (click)="saveDetails(moduleName, topicDescription, thumbnail, isNewTab, isShowBtn, content?.mimeType)"
+                >
+                  {{ moduleButtonName }}
+                </button>
+                <button
+                  [disabled]="isLinkEnabled ? editResourceLinks.length == 0 : true || moduleName == ''"
+                  mat-raised-button
+                  *ngIf="moduleButtonName === 'Save' && content?.contentType !== 'Course' && isLinkEnabled"
+                  class="width-15 text-white mat-button-base save-btn-bottom resourcePdfSave"
+                  (click)="saveDetails(moduleName, topicDescription, thumbnail, isNewTab, isShowBtn, content?.mimeType)"
+                >
+                  {{ moduleButtonName }}
+                </button>
+                <button
+                  mat-raised-button
+                  *ngIf="
+                    moduleButtonName === 'Save' &&
+                    content?.contentType !== 'Course' &&
+                    !isLinkEnabled &&
+                    content?.mimeType === 'application/json'
+                  "
+                  class="width-15 text-white mat-button-base save-btn-bottom resourcePdfSave"
+                  (click)="saveDetails(moduleName, topicDescription, thumbnail, isNewTab, isShowBtn, content?.mimeType)"
+                >
+                  {{ moduleButtonName }}
+                </button>
+                <button
+                  mat-raised-button
+                  *ngIf="content?.contentType === 'Course'"
+                  class="width-15 text-white mat-button-base save-btn-bottom resourcePdfSave"
+                  (click)="saveCourseDetails()"
+                >
+                  Save
                 </button>
               </div>
-              <span class="mc-upload-info">Files allowed: {{uploadText}} &nbsp;·&nbsp; Max. file size: 200 MB</span>
             </div>
-
-            <!-- Video uploaded -->
-            <div *ngIf="uploadVideoUrl && content?.mimeType === 'video/mp4'" class="mc-video-preview">
-              <video #videoPlayer width="100%" height="auto" crossorigin="anonymous"
-                [poster]="uploadVideoUrl" class="video-js" controls
-                (loadedmetadata)="onVideoMetadataLoaded($event)">
-                <source [src]="uploadVideoUrl" type="video/mp4">
-                <source [src]="uploadVideoUrl" type="application/x-mpegURL">
-                <track kind="captions" [src]="uploadVideoUrl" srclang="en" label="English" default>
-              </video>
+            <div class="module-txt-block mc-form-field-row" *ngIf="content?.contentType === 'Course'">
+              <input
+                name="moduleName"
+                type="text"
+                matInput
+                [(ngModel)]="moduleName"
+                #module
+                class="module-input"
+                placeholder="Name of the Course"
+                autocomplete="off"
+                maxlength="250"
+              />
+              <div class="mc-field-footer">
+                <span *ngIf="moduleName == ''" class="invalid-text">This field is Required</span>
+                <mat-hint class="mt-hint">{{ moduleName.length }}/250</mat-hint>
+              </div>
             </div>
-
-          </div>
-          <div class="module-txt-block" *ngIf="isLinkEnabled">
-            <label class="rd-checkbox-item">
-              <input type="checkbox" [(ngModel)]="isNewTab" [checked]="isNewTab" />
-              <span>Open link in new tab</span>
-            </label>
-          </div>
-          <div class="module-txt-block" *ngIf="content?.isAssessment&&!isSelfAssessment">
-            <label class="rd-checkbox-item">
-              <input type="checkbox" [(ngModel)]="content.isCorrectAnswerPopUp" />
-              <span>Show Correct Answer Popup</span>
-            </label>
-          </div>
-          <div class="module-txt-block" *ngIf="content?.mimeType === 'application/json'&&isAddOrEdit">
-            <button mat-raised-button
-              class="text-white ws-mat-primary-background mat-button-base save-btn-bottom"
-              (click)="editAssessmentRes(content)">Edit {{content?.isAssessment?'Assessment':'Quiz'}}</button>
-          </div>
-          <div class="module-txt-block" *ngIf="content?.mimeType === 'application/json'&&!isAddOrEdit">
-            <button *ngIf="!isSelfAssessment" mat-raised-button
-              class="text-white ws-mat-primary-background mat-button-base save-btn-bottom"
-              (click)="editAssessmentRes(content)">Add {{content?.isAssessment?'Assessment':'Quiz'}}</button>
-            <button *ngIf="isSelfAssessment" mat-raised-button
-              class="text-white ws-mat-primary-background mat-button-base save-btn-bottom"
-              (click)="editAssessmentRes(content)">Add Assessment</button>
-          </div>
-          <span *ngIf="content?.mimeType === 'application/json' && !isSelfAssessment"
-            class="margin-top-s module-txt-block quiz-help-txt">Note: You will be taken to
-            {{content?.isAssessment?'Assessment':'Quiz'}} builder
-          </span>
-          <span *ngIf="content?.mimeType === 'application/json' && isSelfAssessment"
-            class="margin-top-s module-txt-block quiz-help-txt">Note: You
-            will be taken to Assessment builder
-          </span>
-
-
-          <div class="margin-top-s" *ngIf="isSaveModuleFormEnable">
-            <span style="color:#808080" *ngIf="content?.contentType === 'Course'">Course Thumbnail</span>
-          </div>
-          <div class="mc-thumbnail-row module-txt-block margin-top-s" *ngIf="content?.contentType === 'CourseUnit'">
-            <input type="file" #uploadThumbnail
-              (change)="uploadAppIcon($event.target.files[0]); uploadThumbnail.value = null" style="display: none"
-              [accept]="imageTypes.toString()" />
-            <div class="mc-thumbnail-upload" (click)="uploadThumbnail.click()">
-              <ng-container *ngIf="thumbnail">
-                <img alt="Module thumbnail" class="mc-thumbnail-preview" [src]="thumbnail"
-                  (error)="changeToDefaultImg($event)" />
-                <button mat-icon-button class="mc-thumbnail-replace-btn"
-                  (click)="$event.stopPropagation(); uploadThumbnail.click()"
-                  matTooltip="Replace thumbnail">
-                  <mat-icon>edit</mat-icon>
+            <div class="module-txt-block mc-form-field-row" *ngIf="content?.contentType === 'CourseUnit' && !isSelfAssessment">
+              <input
+                name="moduleName"
+                type="text"
+                matInput
+                [(ngModel)]="moduleName"
+                #module
+                class="module-input"
+                placeholder="Name of the Module"
+                autocomplete="off"
+                maxlength="100"
+              />
+              <div class="mc-field-footer">
+                <span *ngIf="moduleName == ''" class="invalid-text">This field is Required</span>
+                <mat-hint class="mt-hint">{{ moduleName.length }}/100</mat-hint>
+              </div>
+            </div>
+            <div class="module-txt-block mc-form-field-row" *ngIf="content?.contentType === 'Resource' && !isSelfAssessment">
+              <div class="mc-input-row">
+                <input
+                  name="moduleName"
+                  type="text"
+                  matInput
+                  [(ngModel)]="moduleName"
+                  #module
+                  class="module-input"
+                  placeholder="Name of the Resource"
+                  autocomplete="off"
+                  maxlength="100"
+                />
+                <button
+                  *ngIf="uploadVideoUrl && content?.mimeType === 'video/mp4'"
+                  class="re-upload-btn mat-button-base"
+                  (click)="deleteUploadedFile(); $event.stopPropagation()"
+                >
+                  <img alt="" src="cbp-assets/icons/mage_reload.svg" style="width: 16px; height: 16px" /> Re-upload
                 </button>
-              </ng-container>
-              <ng-container *ngIf="!thumbnail">
-                <mat-icon class="mc-thumbnail-icon">add_photo_alternate</mat-icon>
-                <span class="mc-thumbnail-label" i18n>+ Add Thumbnail</span>
-              </ng-container>
+              </div>
+              <div class="mc-field-footer">
+                <span *ngIf="moduleName == ''" class="invalid-text">This field is Required</span>
+                <mat-hint class="mt-hint">{{ moduleName.length }}/100</mat-hint>
+              </div>
             </div>
-            <div class="mc-thumbnail-specs">
-              <p class="mc-thumbnail-specs-title" i18n>Thumbnail specifications</p>
-              <ul class="mc-thumbnail-specs-list">
-                <li i18n>Max file size: 1 MB</li>
-                <li i18n>Resolution: 760 × 400 px</li>
-                <li i18n>Ratio: 256(w) × 150(h)</li>
-                <li i18n>Formats: JPG, PNG</li>
-              </ul>
+            <div class="module-txt-block mc-form-field-row" *ngIf="content?.contentType === 'Collection'">
+              <input
+                name="moduleName"
+                type="text"
+                matInput
+                [(ngModel)]="moduleName"
+                #module
+                class="module-input"
+                placeholder="Name of the Resource"
+                autocomplete="off"
+                maxlength="100"
+              />
+              <div class="mc-field-footer">
+                <span *ngIf="moduleName == ''" class="invalid-text">This field is Required</span>
+                <mat-hint class="mt-hint">{{ moduleName.length }}/100</mat-hint>
+              </div>
             </div>
-          </div>
-          <div class="duration-style module-txt-block margin-bottom-s"
-            *ngIf="content?.mimeType !== 'application/json'&&content?.contentType !== 'Course'&&content?.contentType !== 'CourseUnit'">
-            <span class="duration-text">Duration:</span>
-            <!-- <mat-form-field appearance="outline" class="width-55"> -->
-            <input matInput class="numberInput" [(ngModel)]="hours" [ngModelOptions]="{ standalone: true }"
-              placeholder="hh" type="number" min="0" max="12" step="1"
-              onkeydown="javascript: return ['Backspace','Delete','ArrowLeft','ArrowRight'].includes(event.code) ? true : !isNaN(Number(event.key)) && event.code!=='Space'" />
-            <!-- </mat-form-field> -->
-            <div class="colon-block">:</div>
-            <!-- <mat-form-field appearance="outline" class="width-55"> -->
-            <input matInput class="numberInput" [(ngModel)]="minutes" [ngModelOptions]="{ standalone: true }"
-              placeholder="mm" type="number" min="0" max="59" step="1"
-              onkeydown="javascript: return ['Backspace','Delete','ArrowLeft','ArrowRight'].includes(event.code) ? true : !isNaN(Number(event.key)) && event.code!=='Space'" />
-            <!-- </mat-form-field> -->
-            <div class="colon-block">:</div>
-            <!-- <mat-form-field appearance="outline" class="width-55"> -->
-            <input matInput class="numberInput" [(ngModel)]="seconds" [ngModelOptions]="{ standalone: true }"
-              placeholder="ss" type="number" min="0" max="59" step="1"
-              onkeydown="javascript: return ['Backspace','Delete','ArrowLeft','ArrowRight'].includes(event.code) ? true : !isNaN(Number(event.key)) && event.code!=='Space'" />
-            <!-- </mat-form-field> -->
-
-
-          </div>
-
-          <span
-            *ngIf="!hours&&!minutes&&!seconds&&content?.contentType !== 'CourseUnit'&&content?.mimeType !== 'application/json'"
-            class="module-txt-block invalid-text">This
-            field
-            is Required</span>
-          <!-- To add question to video resource-->
-          <div class="module-txt-block margin-top-m" *ngIf="content?.mimeType === 'video/mp4'">
-            <span [ngClass]="{'disabled-text': !uploadVideoUrl&&uploadFileName == ''|| videoQuestions.length >= 4}"
-              class="video-quiz-text">Add
-              In-video Quiz</span>
-          </div>
-          <div class="module-txt-block margin-top-xs" *ngIf="content?.mimeType === 'video/mp4'">
-            <button [disabled]="!uploadVideoUrl && uploadFileName == '' ||videoQuestions.length >= 4"
-              class="add-video-question-btn margin-bottom-m text-white save-btn-bottom" (click)="addVideoQuestion()">Add
-              Quiz</button>
-          </div>
-
-          <ng-container *ngTemplateOutlet="videoQuizFormTpl; context: { useResourceSave: false }"></ng-container>
-        </div>
-
-        <!--Onclick of reosurce type page-->
-        <div class="module-right-content scroll-bar"
-          *ngIf="!isResourceTypeEnabled && showAddModuleForm && isOnClickOfResourceTypeEnabled">
-          <div class="module-resource-title-block">
-            <div>
-              <span class="course-sub-title">Resource Details</span>
+            <div class="module-txt-block margin-top-l" *ngIf="isSelfAssessment">
+              <span class="self-assessment-name">{{ moduleName }}</span>
             </div>
-            <div class="save-btn-block">
-              <button mat-icon-button class="mc-delete-icon-btn" (click)="takeActions('delete', content, $event.type)"
-                matTooltip="Delete">
-                <mat-icon>delete_outline</mat-icon>
-              </button>
-              <button *ngIf="isLinkEnabled||isAssessmentOrQuizEnabled"
-                [disabled]="editResourceLinks.length==0&&!isAssessmentOrQuizEnabled" mat-raised-button
-                class="width-15 text-white mat-button-base save-btn-bottom resourcePdfSave"
-                (click)="resourceLinkSave()">Save</button>
-              <button *ngIf="isPdfOrAudioOrVedioEnabled" [disabled]="uploadFileName==''" mat-raised-button
-                class="width-15 text-white mat-button-base save-btn-bottom resourcePdfSave"
-                (click)="resourcePdfSave()">Save</button>
+            <div class="module-txt-block" *ngIf="content?.mimeType === 'application/json' && !isSelfAssessment">
+              <ng-container *ngTemplateOutlet="assessmentWarningTpl"></ng-container>
             </div>
-          </div>
-          <div>
-            <!--link form start-->
-            <form [formGroup]="resourceLinkForm" class="resource-details-form"
-              *ngIf="isLinkEnabled||isAssessmentOrQuizEnabled">
-
-              <!-- Name of the resource -->
-              <div class="rd-name-row">
-                <input type="text" #name formControlName="name" maxlength="100"
-                  placeholder="Name of the resource" class="module-input" autocomplete="off" />
-                <div class="rd-field-footer">
-                  <span *ngIf="resourceLinkForm.get('name').hasError('required')" class="invalid-text">This field is Required</span>
-                  <span class="mt-hint">{{ resourceLinkForm.value.name.length }}/100</span>
+            <!-- is link enabled -->
+            <div class="module-txt-block" *ngIf="isLinkEnabled">
+              <input
+                #artifactUrl
+                name="moduleName"
+                type="text"
+                matInput
+                [(ngModel)]="editResourceLinks"
+                class="module-input margin-top-xs field-width"
+                placeholder="Link"
+                autocomplete="off"
+                maxlength="100"
+                i18n-placeholder
+              />
+            </div>
+            <div *ngIf="isLinkEnabled" class="margin-bottom-s margin-top-s module-txt-block">
+              <span style="color: #808080 !important">Note : A link can be a URL or an Youtube embeded link</span>
+            </div>
+            <div class="module-txt-block margin-top-s" *ngIf="isLinkEnabled">
+              <span *ngIf="editResourceLinks == ''" class="invalid-text">This field is Required</span>
+            </div>
+            <!-- is pdf/video/audio/zip -->
+            <div class="module-txt-block margin-top-s" *ngIf="isPdfOrAudioOrVedioEnabled && content?.mimeType !== 'application/json'">
+              <!-- No file yet — upload card -->
+              <ng-container *ngIf="uploadFileName == '' && !uploadVideoUrl">
+                <div class="mc-upload-card" (click)="pdfFile.click()">
+                  <input
+                    #pdfFile
+                    (change)="uploadPdf($event.target.files[0]); pdfFile.value = null"
+                    style="display: none"
+                    accept="{{ acceptType }}"
+                    type="file"
+                  />
+                  <!-- show resource-type icon only when set, otherwise use generic upload icon -->
+                  <img *ngIf="resourceImg" class="mc-upload-type-icon" [src]="resourceImg" alt="" />
+                  <mat-icon *ngIf="!resourceImg" class="mc-upload-icon-fallback">upload_file</mat-icon>
+                  <button mat-stroked-button class="mc-upload-btn" (click)="pdfFile.click(); $event.stopPropagation()">
+                    <mat-icon>upload</mat-icon>
+                    Upload File
+                  </button>
+                  <span class="mc-upload-info"
+                    >Files allowed: {{ uploadText || 'PDF, MP3, MP4, ZIP' }} &nbsp;·&nbsp; Max. file size: 200 MB</span
+                  >
                 </div>
+                <span *ngIf="acceptType == '.pdf'" class="mc-upload-note">Note: The PDF should have high resolution</span>
+              </ng-container>
+
+              <!-- File uploaded (non-video) -->
+              <div class="mc-uploaded-row" *ngIf="uploadFileName != '' && content?.mimeType !== 'video/mp4'">
+                <div class="mc-uploaded-file-card">
+                  <img alt="" class="uploaded-img" src="{{ uploadIcon }}" />
+                  <span class="text-wrap mc-uploaded-name">{{ uploadFileName }}</span>
+                  <button
+                    mat-icon-button
+                    class="mc-remove-file-btn"
+                    (click)="deleteUploadedFile(); $event.stopPropagation()"
+                    matTooltip="Remove file"
+                  >
+                    <mat-icon>close</mat-icon>
+                  </button>
+                </div>
+                <span class="mc-upload-info">Files allowed: {{ uploadText }} &nbsp;·&nbsp; Max. file size: 200 MB</span>
               </div>
 
-              <!-- Save-before-adding warning (assessment / quiz) -->
-              <div *ngIf="isAssessmentOrQuizEnabled && !isSelfAssessment">
-                <ng-container *ngTemplateOutlet="assessmentWarningTpl"></ng-container>
+              <!-- Video uploaded -->
+              <div *ngIf="uploadVideoUrl && content?.mimeType === 'video/mp4'" class="mc-video-preview">
+                <video
+                  #videoPlayer
+                  width="100%"
+                  height="auto"
+                  crossorigin="anonymous"
+                  [poster]="uploadVideoUrl"
+                  class="video-js"
+                  controls
+                  (loadedmetadata)="onVideoMetadataLoaded($event)"
+                >
+                  <source [src]="uploadVideoUrl" type="video/mp4" />
+                  <source [src]="uploadVideoUrl" type="application/x-mpegURL" />
+                  <track kind="captions" [src]="uploadVideoUrl" srclang="en" label="English" default />
+                </video>
               </div>
-
-              <!-- Show Correct Answer Popup (assessment only) -->
-              <label class="rd-checkbox-item"
-                *ngIf="isAssessmentOrQuizEnabled && content?.isAssessment && !isSelfAssessment">
-                <input type="checkbox" [(ngModel)]="content.isCorrectAnswerPopUp"
-                  [ngModelOptions]="{standalone: true}" />
+            </div>
+            <div class="module-txt-block" *ngIf="isLinkEnabled">
+              <label class="rd-checkbox-item">
+                <input type="checkbox" [(ngModel)]="isNewTab" [checked]="isNewTab" />
+                <span>Open link in new tab</span>
+              </label>
+            </div>
+            <!-- Show Correct Answer Popup — Assessment resources only (not quiz / self-assessment / pdf / etc.) -->
+            <div class="module-txt-block" *ngIf="isAssessmentResource">
+              <label class="rd-checkbox-item">
+                <input type="checkbox" [(ngModel)]="content.isCorrectAnswerPopUp" />
                 <span>Show Correct Answer Popup</span>
               </label>
+            </div>
+            <div class="module-txt-block" *ngIf="content?.mimeType === 'application/json' && isAddOrEdit">
+              <button
+                mat-raised-button
+                class="text-white ws-mat-primary-background mat-button-base save-btn-bottom"
+                (click)="editAssessmentRes(content)"
+              >
+                Edit {{ content?.isAssessment ? 'Assessment' : 'Quiz' }}
+              </button>
+            </div>
+            <div class="module-txt-block" *ngIf="content?.mimeType === 'application/json' && !isAddOrEdit">
+              <button
+                *ngIf="!isSelfAssessment"
+                mat-raised-button
+                class="text-white ws-mat-primary-background mat-button-base save-btn-bottom"
+                (click)="editAssessmentRes(content)"
+              >
+                Add {{ content?.isAssessment ? 'Assessment' : 'Quiz' }}
+              </button>
+              <button
+                *ngIf="isSelfAssessment"
+                mat-raised-button
+                class="text-white ws-mat-primary-background mat-button-base save-btn-bottom"
+                (click)="editAssessmentRes(content)"
+              >
+                Add Assessment
+              </button>
+            </div>
+            <span *ngIf="content?.mimeType === 'application/json' && !isSelfAssessment" class="margin-top-s module-txt-block quiz-help-txt"
+              >Note: You will be taken to {{ content?.isAssessment ? 'Assessment' : 'Quiz' }} builder
+            </span>
+            <span *ngIf="content?.mimeType === 'application/json' && isSelfAssessment" class="margin-top-s module-txt-block quiz-help-txt"
+              >Note: You will be taken to Assessment builder
+            </span>
 
-              <!-- Link URL (link type only) -->
-              <div class="rd-name-row" *ngIf="isLinkEnabled && !isAssessmentOrQuizEnabled">
-                <input type="text" #artifactUrl [(ngModel)]="editResourceLinks" formControlName="artifactUrl"
-                  maxlength="100" placeholder="Link" class="module-input" autocomplete="off" />
-                <span *ngIf="resourceLinkForm.get('artifactUrl').hasError('required')" class="invalid-text">This field is Required</span>
-              </div>
-
-              <!-- Link hint (link type only) -->
-              <span class="quiz-help-txt" *ngIf="!isAssessmentOrQuizEnabled">
-                Note : A link can be a URL or a Youtube embedded link
-              </span>
-
-              <!-- Open in new tab (link type only) -->
-              <label class="rd-checkbox-item" *ngIf="isLinkEnabled">
-                <input type="checkbox" formControlName="isIframeSupported" />
-                <span>Open link in new tab</span>
-              </label>
-
-              <!-- Add Questions button (assessment / quiz) -->
-              <div *ngIf="isAssessmentOrQuizEnabled">
-                <button mat-raised-button
-                  class="text-white ws-mat-primary-background mat-button-base save-btn-bottom"
-                  (click)="addAssessment()">Add Questions</button>
-              </div>
-
-              <!-- Builder note (assessment / quiz only) -->
-              <span class="quiz-help-txt" *ngIf="isAssessmentOrQuizEnabled">
-                Note: You will be taken to {{content?.isAssessment ? 'Assessment' : 'Quiz'}} builder
-              </span>
-
-              <!-- Duration (link type only) -->
-              <div class="duration-style" *ngIf="!isAssessmentOrQuizEnabled">
-                <span class="duration-text">Duration:</span>
-                <input matInput class="numberInput" [(ngModel)]="hours" [ngModelOptions]="{ standalone: true }"
-                  (keyup)="this.resourceLinkForm.controls.duration.setValue(this.timeToSeconds())"
-                  placeholder="hh" type="number" min="0" step="1"
-                  onkeydown="javascript: return ['Backspace','Delete','ArrowLeft','ArrowRight'].includes(event.code) ? true : !isNaN(Number(event.key)) && event.code!=='Space'" />
-                <div class="colon-block">:</div>
-                <input matInput class="numberInput" [(ngModel)]="minutes" [ngModelOptions]="{ standalone: true }"
-                  (keyup)="this.resourceLinkForm.controls.duration.setValue(this.timeToSeconds())"
-                  placeholder="mm" type="number" min="0" max="59" step="1"
-                  onkeydown="javascript: return ['Backspace','Delete','ArrowLeft','ArrowRight'].includes(event.code) ? true : !isNaN(Number(event.key)) && event.code!=='Space'" />
-                <div class="colon-block">:</div>
-                <input matInput class="numberInput" [(ngModel)]="seconds" [ngModelOptions]="{ standalone: true }"
-                  (keyup)="this.resourceLinkForm.controls.duration.setValue(this.timeToSeconds())"
-                  placeholder="ss" type="number" min="0" max="59" step="1"
-                  onkeydown="javascript: return ['Backspace','Delete','ArrowLeft','ArrowRight'].includes(event.code) ? true : !isNaN(Number(event.key)) && event.code!=='Space'" />
-              </div>
-              <span *ngIf="resourceLinkForm.get('duration').hasError('required') && !isAssessmentOrQuizEnabled"
-                class="invalid-text">This field is Required</span>
-
-            </form>
-            <!--link form end-->
-            <!--PDF/audio/vedio form start-->
-            <form [formGroup]="resourcePdfForm" class="resource-details-form" *ngIf="isPdfOrAudioOrVedioEnabled">
-              <!-- Name row + optional re-upload (video only) -->
-              <div class="rd-pdf-name-row">
-                <div class="rd-name-row" style="flex:1;min-width:0;">
-                  <input type="text" #name formControlName="name" maxlength="100"
-                    placeholder="Name of the resource" class="module-input" autocomplete="off" />
-                  <div class="rd-field-footer">
-                    <span *ngIf="resourcePdfForm.get('name').hasError('required')" class="invalid-text">This field is Required</span>
-                    <span class="mt-hint">{{ resourcePdfForm.value.name.length }}/100</span>
-                  </div>
-                </div>
-                <ng-container
-                  *ngIf="content?.contentType === 'Resource' && uploadVideoUrl && content?.mimeType === 'video/mp4'">
-                  <button class="re-upload-btn mat-button-base"
-                    (click)="deleteUploadedFile();$event.stopPropagation()">
-                    <img alt="" src="cbp-assets/icons/mage_reload.svg" style="width:16px;height:16px;">Re-upload
+            <div class="margin-top-s" *ngIf="isSaveModuleFormEnable">
+              <span style="color: #808080" *ngIf="content?.contentType === 'Course'">Course Thumbnail</span>
+            </div>
+            <div class="mc-thumbnail-row module-txt-block margin-top-s" *ngIf="content?.contentType === 'CourseUnit'">
+              <input
+                type="file"
+                #uploadThumbnail
+                (change)="uploadAppIcon($event.target.files[0]); uploadThumbnail.value = null"
+                style="display: none"
+                [accept]="imageTypes.toString()"
+              />
+              <div class="mc-thumbnail-upload" (click)="uploadThumbnail.click()">
+                <ng-container *ngIf="thumbnail">
+                  <img alt="Module thumbnail" class="mc-thumbnail-preview" [src]="thumbnail" (error)="changeToDefaultImg($event)" />
+                  <button
+                    mat-icon-button
+                    class="mc-thumbnail-replace-btn"
+                    (click)="$event.stopPropagation(); uploadThumbnail.click()"
+                    matTooltip="Replace thumbnail"
+                  >
+                    <mat-icon>edit</mat-icon>
                   </button>
                 </ng-container>
-              </div>
-              <!-- No file yet — upload card -->
-              <div class="module-txt-block margin-top-s">
-                <ng-container *ngIf="uploadFileName == '' && !uploadVideoUrl">
-                  <div class="mc-upload-card" (click)="pdfFile2.click()">
-                    <input #pdfFile2 (change)="uploadPdf($event.target.files[0]); pdfFile2.value = null"
-                      style="display: none;" accept="{{acceptType}}" type="file" />
-                    <img *ngIf="resourceImg" class="mc-upload-type-icon" [src]="resourceImg" alt="" />
-                    <mat-icon *ngIf="!resourceImg" class="mc-upload-icon-fallback">upload_file</mat-icon>
-                    <button mat-stroked-button class="mc-upload-btn"
-                      (click)="pdfFile2.click(); $event.stopPropagation()">
-                      <mat-icon>upload</mat-icon>
-                      Upload File
-                    </button>
-                    <span class="mc-upload-info">Files allowed: {{uploadText || 'PDF, MP3, MP4, ZIP'}} &nbsp;·&nbsp; Max. file size: 200 MB</span>
-                  </div>
-                  <span *ngIf="acceptType == '.pdf'" class="mc-upload-note">Note: The PDF should have high resolution</span>
+                <ng-container *ngIf="!thumbnail">
+                  <mat-icon class="mc-thumbnail-icon">add_photo_alternate</mat-icon>
+                  <span class="mc-thumbnail-label" i18n>+ Add Thumbnail</span>
                 </ng-container>
-
-                <!-- File uploaded (non-video) -->
-                <div class="mc-uploaded-row" *ngIf="uploadFileName != '' && content?.mimeType !== 'video/mp4'">
-                  <div class="mc-uploaded-file-card">
-                    <img alt="" class="uploaded-img" src="{{uploadIcon}}" />
-                    <span class="text-wrap mc-uploaded-name">{{uploadFileName}}</span>
-                    <button mat-icon-button class="mc-remove-file-btn"
-                      (click)="deleteUploadedFile(); $event.stopPropagation()" matTooltip="Remove file">
-                      <mat-icon>close</mat-icon>
-                    </button>
-                  </div>
-                  <span class="mc-upload-info">Files allowed: {{uploadText}} &nbsp;·&nbsp; Max. file size: 200 MB</span>
-                </div>
-
-                <!-- Video uploaded -->
-                <div *ngIf="uploadVideoUrl && content?.mimeType === 'video/mp4'" class="mc-video-preview">
-                  <video #videoPlayer2 width="100%" height="auto" crossorigin="anonymous"
-                    [poster]="uploadVideoUrl" class="video-js" controls
-                    (loadedmetadata)="onVideoMetadataLoaded($event)">
-                    <source [src]="uploadVideoUrl" type="video/mp4">
-                    <source [src]="uploadVideoUrl" type="application/x-mpegURL">
-                    <track kind="captions" [src]="uploadVideoUrl" srclang="en" label="English" default>
-                  </video>
-                </div>
-
-                <span *ngIf="isSaveModuleFormEnable && uploadFileName == ''" class="invalid-text mc-upload-error">
-                  This field is Required
-                </span>
               </div>
-              <label class="rd-checkbox-item" *ngIf="isLinkEnabled">
-                <input type="checkbox" formControlName="isIframeSupported" />
-                <span>Open link in new tab</span>
-              </label>
-              <!-- <div class="margin-top-m" style="display:flex; flex-direction:row" *ngIf="isShowDownloadBtnEnabled">
+              <div class="mc-thumbnail-specs">
+                <p class="mc-thumbnail-specs-title" i18n>Thumbnail specifications</p>
+                <ul class="mc-thumbnail-specs-list">
+                  <li i18n>Max file size: 1 MB</li>
+                  <li i18n>Resolution: 760 × 400 px</li>
+                  <li i18n>Ratio: 256(w) × 150(h)</li>
+                  <li i18n>Formats: JPG, PNG</li>
+                </ul>
+              </div>
+            </div>
+            <div
+              class="duration-style module-txt-block margin-bottom-s"
+              *ngIf="content?.mimeType !== 'application/json' && content?.contentType !== 'Course' && content?.contentType !== 'CourseUnit'"
+            >
+              <span class="duration-text">Duration:</span>
+              <!-- <mat-form-field appearance="outline" class="width-55"> -->
+              <input
+                matInput
+                class="numberInput"
+                [(ngModel)]="hours"
+                [ngModelOptions]="{ standalone: true }"
+                placeholder="hh"
+                type="number"
+                min="0"
+                max="12"
+                step="1"
+                onkeydown="
+                  javascript: return ['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight'].includes(event.code)
+                    ? true
+                    : !isNaN(Number(event.key)) && event.code !== 'Space'
+                "
+              />
+              <!-- </mat-form-field> -->
+              <div class="colon-block">:</div>
+              <!-- <mat-form-field appearance="outline" class="width-55"> -->
+              <input
+                matInput
+                class="numberInput"
+                [(ngModel)]="minutes"
+                [ngModelOptions]="{ standalone: true }"
+                placeholder="mm"
+                type="number"
+                min="0"
+                max="59"
+                step="1"
+                onkeydown="
+                  javascript: return ['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight'].includes(event.code)
+                    ? true
+                    : !isNaN(Number(event.key)) && event.code !== 'Space'
+                "
+              />
+              <!-- </mat-form-field> -->
+              <div class="colon-block">:</div>
+              <!-- <mat-form-field appearance="outline" class="width-55"> -->
+              <input
+                matInput
+                class="numberInput"
+                [(ngModel)]="seconds"
+                [ngModelOptions]="{ standalone: true }"
+                placeholder="ss"
+                type="number"
+                min="0"
+                max="59"
+                step="1"
+                onkeydown="
+                  javascript: return ['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight'].includes(event.code)
+                    ? true
+                    : !isNaN(Number(event.key)) && event.code !== 'Space'
+                "
+              />
+              <!-- </mat-form-field> -->
+            </div>
+
+            <span
+              *ngIf="!hours && !minutes && !seconds && content?.contentType !== 'CourseUnit' && content?.mimeType !== 'application/json'"
+              class="module-txt-block invalid-text"
+              >This field is Required</span
+            >
+            <!-- To add question to video resource-->
+            <div class="module-txt-block margin-top-m" *ngIf="content?.mimeType === 'video/mp4'">
+              <span
+                [ngClass]="{ 'disabled-text': (!uploadVideoUrl && uploadFileName == '') || videoQuestions.length >= 4 }"
+                class="video-quiz-text"
+                >Add In-video Quiz</span
+              >
+            </div>
+            <div class="module-txt-block margin-top-xs" *ngIf="content?.mimeType === 'video/mp4'">
+              <button
+                [disabled]="(!uploadVideoUrl && uploadFileName == '') || videoQuestions.length >= 4"
+                class="add-video-question-btn margin-bottom-m text-white save-btn-bottom"
+                (click)="addVideoQuestion()"
+              >
+                Add Quiz
+              </button>
+            </div>
+
+            <ng-container *ngTemplateOutlet="videoQuizFormTpl; context: { useResourceSave: false }"></ng-container>
+          </div>
+
+          <!--Onclick of reosurce type page-->
+          <div
+            class="module-right-content scroll-bar"
+            *ngIf="!isResourceTypeEnabled && showAddModuleForm && isOnClickOfResourceTypeEnabled"
+          >
+            <div class="module-resource-title-block">
+              <div>
+                <span class="course-sub-title">Resource Details</span>
+              </div>
+              <div class="save-btn-block">
+                <button
+                  mat-icon-button
+                  class="mc-delete-icon-btn"
+                  (click)="takeActions('delete', content, $event.type)"
+                  matTooltip="Delete"
+                >
+                  <mat-icon>delete_outline</mat-icon>
+                </button>
+                <button
+                  *ngIf="isLinkEnabled || isAssessmentOrQuizEnabled"
+                  [disabled]="editResourceLinks.length == 0 && !isAssessmentOrQuizEnabled"
+                  mat-raised-button
+                  class="width-15 text-white mat-button-base save-btn-bottom resourcePdfSave"
+                  (click)="resourceLinkSave()"
+                >
+                  Save
+                </button>
+                <button
+                  *ngIf="isPdfOrAudioOrVedioEnabled"
+                  [disabled]="uploadFileName == ''"
+                  mat-raised-button
+                  class="width-15 text-white mat-button-base save-btn-bottom resourcePdfSave"
+                  (click)="resourcePdfSave()"
+                >
+                  Save
+                </button>
+              </div>
+            </div>
+            <div>
+              <!--link form start-->
+              <form [formGroup]="resourceLinkForm" class="resource-details-form" *ngIf="isLinkEnabled || isAssessmentOrQuizEnabled">
+                <!-- Name of the resource -->
+                <div class="rd-name-row">
+                  <input
+                    type="text"
+                    #name
+                    formControlName="name"
+                    maxlength="100"
+                    placeholder="Name of the resource"
+                    class="module-input"
+                    autocomplete="off"
+                  />
+                  <div class="rd-field-footer">
+                    <span *ngIf="resourceLinkForm.get('name').hasError('required')" class="invalid-text">This field is Required</span>
+                    <span class="mt-hint">{{ resourceLinkForm.value.name.length }}/100</span>
+                  </div>
+                </div>
+
+                <!-- Save-before-adding warning (assessment / quiz) -->
+                <div *ngIf="isAssessmentOrQuizEnabled && !isSelfAssessment">
+                  <ng-container *ngTemplateOutlet="assessmentWarningTpl"></ng-container>
+                </div>
+
+                <!-- Show Correct Answer Popup — Assessment resources only (not quiz / self-assessment) -->
+                <label class="rd-checkbox-item" *ngIf="isAssessmentResource">
+                  <input type="checkbox" [(ngModel)]="content.isCorrectAnswerPopUp" [ngModelOptions]="{ standalone: true }" />
+                  <span>Show Correct Answer Popup</span>
+                </label>
+
+                <!-- Link URL (link type only) -->
+                <div class="rd-name-row" *ngIf="isLinkEnabled && !isAssessmentOrQuizEnabled">
+                  <input
+                    type="text"
+                    #artifactUrl
+                    [(ngModel)]="editResourceLinks"
+                    formControlName="artifactUrl"
+                    maxlength="100"
+                    placeholder="Link"
+                    class="module-input"
+                    autocomplete="off"
+                  />
+                  <span *ngIf="resourceLinkForm.get('artifactUrl').hasError('required')" class="invalid-text">This field is Required</span>
+                </div>
+
+                <!-- Link hint (link type only) -->
+                <span class="quiz-help-txt" *ngIf="!isAssessmentOrQuizEnabled">
+                  Note : A link can be a URL or a Youtube embedded link
+                </span>
+
+                <!-- Open in new tab (link type only) -->
+                <label class="rd-checkbox-item" *ngIf="isLinkEnabled">
+                  <input type="checkbox" formControlName="isIframeSupported" />
+                  <span>Open link in new tab</span>
+                </label>
+
+                <!-- Add Questions button (assessment / quiz) -->
+                <div *ngIf="isAssessmentOrQuizEnabled">
+                  <button
+                    mat-raised-button
+                    class="text-white ws-mat-primary-background mat-button-base save-btn-bottom"
+                    (click)="addAssessment()"
+                  >
+                    Add Questions
+                  </button>
+                </div>
+
+                <!-- Builder note (assessment / quiz only) -->
+                <span class="quiz-help-txt" *ngIf="isAssessmentOrQuizEnabled">
+                  Note: You will be taken to {{ content?.isAssessment ? 'Assessment' : 'Quiz' }} builder
+                </span>
+
+                <!-- Duration (link type only) -->
+                <div class="duration-style" *ngIf="!isAssessmentOrQuizEnabled">
+                  <span class="duration-text">Duration:</span>
+                  <input
+                    matInput
+                    class="numberInput"
+                    [(ngModel)]="hours"
+                    [ngModelOptions]="{ standalone: true }"
+                    (keyup)="this.resourceLinkForm.controls.duration.setValue(this.timeToSeconds())"
+                    placeholder="hh"
+                    type="number"
+                    min="0"
+                    step="1"
+                    onkeydown="
+                      javascript: return ['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight'].includes(event.code)
+                        ? true
+                        : !isNaN(Number(event.key)) && event.code !== 'Space'
+                    "
+                  />
+                  <div class="colon-block">:</div>
+                  <input
+                    matInput
+                    class="numberInput"
+                    [(ngModel)]="minutes"
+                    [ngModelOptions]="{ standalone: true }"
+                    (keyup)="this.resourceLinkForm.controls.duration.setValue(this.timeToSeconds())"
+                    placeholder="mm"
+                    type="number"
+                    min="0"
+                    max="59"
+                    step="1"
+                    onkeydown="
+                      javascript: return ['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight'].includes(event.code)
+                        ? true
+                        : !isNaN(Number(event.key)) && event.code !== 'Space'
+                    "
+                  />
+                  <div class="colon-block">:</div>
+                  <input
+                    matInput
+                    class="numberInput"
+                    [(ngModel)]="seconds"
+                    [ngModelOptions]="{ standalone: true }"
+                    (keyup)="this.resourceLinkForm.controls.duration.setValue(this.timeToSeconds())"
+                    placeholder="ss"
+                    type="number"
+                    min="0"
+                    max="59"
+                    step="1"
+                    onkeydown="
+                      javascript: return ['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight'].includes(event.code)
+                        ? true
+                        : !isNaN(Number(event.key)) && event.code !== 'Space'
+                    "
+                  />
+                </div>
+                <span *ngIf="resourceLinkForm.get('duration').hasError('required') && !isAssessmentOrQuizEnabled" class="invalid-text"
+                  >This field is Required</span
+                >
+              </form>
+              <!--link form end-->
+              <!--PDF/audio/vedio form start-->
+              <form [formGroup]="resourcePdfForm" class="resource-details-form" *ngIf="isPdfOrAudioOrVedioEnabled">
+                <!-- Name row + optional re-upload (video only) -->
+                <div class="rd-pdf-name-row">
+                  <div class="rd-name-row" style="flex: 1; min-width: 0">
+                    <input
+                      type="text"
+                      #name
+                      formControlName="name"
+                      maxlength="100"
+                      placeholder="Name of the resource"
+                      class="module-input"
+                      autocomplete="off"
+                    />
+                    <div class="rd-field-footer">
+                      <span *ngIf="resourcePdfForm.get('name').hasError('required')" class="invalid-text">This field is Required</span>
+                      <span class="mt-hint">{{ resourcePdfForm.value.name.length }}/100</span>
+                    </div>
+                  </div>
+                  <ng-container *ngIf="content?.contentType === 'Resource' && uploadVideoUrl && content?.mimeType === 'video/mp4'">
+                    <button class="re-upload-btn mat-button-base" (click)="deleteUploadedFile(); $event.stopPropagation()">
+                      <img alt="" src="cbp-assets/icons/mage_reload.svg" style="width: 16px; height: 16px" />Re-upload
+                    </button>
+                  </ng-container>
+                </div>
+                <!-- No file yet — upload card -->
+                <div class="module-txt-block margin-top-s">
+                  <ng-container *ngIf="uploadFileName == '' && !uploadVideoUrl">
+                    <div class="mc-upload-card" (click)="pdfFile2.click()">
+                      <input
+                        #pdfFile2
+                        (change)="uploadPdf($event.target.files[0]); pdfFile2.value = null"
+                        style="display: none"
+                        accept="{{ acceptType }}"
+                        type="file"
+                      />
+                      <img *ngIf="resourceImg" class="mc-upload-type-icon" [src]="resourceImg" alt="" />
+                      <mat-icon *ngIf="!resourceImg" class="mc-upload-icon-fallback">upload_file</mat-icon>
+                      <button mat-stroked-button class="mc-upload-btn" (click)="pdfFile2.click(); $event.stopPropagation()">
+                        <mat-icon>upload</mat-icon>
+                        Upload File
+                      </button>
+                      <span class="mc-upload-info"
+                        >Files allowed: {{ uploadText || 'PDF, MP3, MP4, ZIP' }} &nbsp;·&nbsp; Max. file size: 200 MB</span
+                      >
+                    </div>
+                    <span *ngIf="acceptType == '.pdf'" class="mc-upload-note">Note: The PDF should have high resolution</span>
+                  </ng-container>
+
+                  <!-- File uploaded (non-video) -->
+                  <div class="mc-uploaded-row" *ngIf="uploadFileName != '' && content?.mimeType !== 'video/mp4'">
+                    <div class="mc-uploaded-file-card">
+                      <img alt="" class="uploaded-img" src="{{ uploadIcon }}" />
+                      <span class="text-wrap mc-uploaded-name">{{ uploadFileName }}</span>
+                      <button
+                        mat-icon-button
+                        class="mc-remove-file-btn"
+                        (click)="deleteUploadedFile(); $event.stopPropagation()"
+                        matTooltip="Remove file"
+                      >
+                        <mat-icon>close</mat-icon>
+                      </button>
+                    </div>
+                    <span class="mc-upload-info">Files allowed: {{ uploadText }} &nbsp;·&nbsp; Max. file size: 200 MB</span>
+                  </div>
+
+                  <!-- Video uploaded -->
+                  <div *ngIf="uploadVideoUrl && content?.mimeType === 'video/mp4'" class="mc-video-preview">
+                    <video
+                      #videoPlayer2
+                      width="100%"
+                      height="auto"
+                      crossorigin="anonymous"
+                      [poster]="uploadVideoUrl"
+                      class="video-js"
+                      controls
+                      (loadedmetadata)="onVideoMetadataLoaded($event)"
+                    >
+                      <source [src]="uploadVideoUrl" type="video/mp4" />
+                      <source [src]="uploadVideoUrl" type="application/x-mpegURL" />
+                      <track kind="captions" [src]="uploadVideoUrl" srclang="en" label="English" default />
+                    </video>
+                  </div>
+
+                  <span *ngIf="isSaveModuleFormEnable && uploadFileName == ''" class="invalid-text mc-upload-error">
+                    This field is Required
+                  </span>
+                </div>
+                <label class="rd-checkbox-item" *ngIf="isLinkEnabled">
+                  <input type="checkbox" formControlName="isIframeSupported" />
+                  <span>Open link in new tab</span>
+                </label>
+                <!-- <div class="margin-top-m" style="display:flex; flex-direction:row" *ngIf="isShowDownloadBtnEnabled">
                 <mat-checkbox class="module-txt-block" formControlName="showDownloadBtn">Show
                   Download Button</mat-checkbox>
               </div> -->
-              <div class="margin-top-m duration-style module-txt-block">
-                <span class="duration-text">Duration:</span><br>
-                <input matInput class="numberInput" [(ngModel)]="hours" [ngModelOptions]="{ standalone: true }"
-                  (keyup)="this.resourcePdfForm.controls.duration.setValue(this.timeToSeconds())" placeholder="hh"
-                  type="number" min="0" step="1"
-                  onkeydown="javascript: return ['Backspace','Delete','ArrowLeft','ArrowRight'].includes(event.code) ? true : !isNaN(Number(event.key)) && event.code!=='Space'" />
-                <div class="colon-block">:</div>
+                <div class="margin-top-m duration-style module-txt-block">
+                  <span class="duration-text">Duration:</span><br />
+                  <input
+                    matInput
+                    class="numberInput"
+                    [(ngModel)]="hours"
+                    [ngModelOptions]="{ standalone: true }"
+                    (keyup)="this.resourcePdfForm.controls.duration.setValue(this.timeToSeconds())"
+                    placeholder="hh"
+                    type="number"
+                    min="0"
+                    step="1"
+                    onkeydown="
+                      javascript: return ['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight'].includes(event.code)
+                        ? true
+                        : !isNaN(Number(event.key)) && event.code !== 'Space'
+                    "
+                  />
+                  <div class="colon-block">:</div>
 
-                <input matInput class="numberInput" [(ngModel)]="minutes" [ngModelOptions]="{ standalone: true }"
-                  (keyup)="this.resourcePdfForm.controls.duration.setValue(this.timeToSeconds())" placeholder="mm"
-                  type="number" min="0" max="59" step="1"
-                  onkeydown="javascript: return ['Backspace','Delete','ArrowLeft','ArrowRight'].includes(event.code) ? true : !isNaN(Number(event.key)) && event.code!=='Space'" />
-                <div class="colon-block">:</div>
+                  <input
+                    matInput
+                    class="numberInput"
+                    [(ngModel)]="minutes"
+                    [ngModelOptions]="{ standalone: true }"
+                    (keyup)="this.resourcePdfForm.controls.duration.setValue(this.timeToSeconds())"
+                    placeholder="mm"
+                    type="number"
+                    min="0"
+                    max="59"
+                    step="1"
+                    onkeydown="
+                      javascript: return ['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight'].includes(event.code)
+                        ? true
+                        : !isNaN(Number(event.key)) && event.code !== 'Space'
+                    "
+                  />
+                  <div class="colon-block">:</div>
 
-                <input matInput class="numberInput" [(ngModel)]="seconds" [ngModelOptions]="{ standalone: true }"
-                  (keyup)="this.resourcePdfForm.controls.duration.setValue(this.timeToSeconds())" placeholder="ss"
-                  type="number" min="0" max="59" step="1"
-                  onkeydown="javascript: return ['Backspace','Delete','ArrowLeft','ArrowRight'].includes(event.code) ? true : !isNaN(Number(event.key)) && event.code!=='Space'" />
-              </div>
-              <span *ngIf="resourcePdfForm.get('duration').hasError('required')"
-                class="module-txt-block invalid-text">This
-                field
-                is Required</span>
-              <div class="module-txt-block margin-top-m" *ngIf="content?.mimeType === 'video/mp4'">
-                <span [ngClass]="{'disabled-text': !uploadVideoUrl&&uploadFileName == ''|| videoQuestions.length >= 4}"
-                  class="video-quiz-text">Add
-                  In-video Quiz</span>
-              </div>
-              <div class="module-txt-block margin-top-xs" *ngIf="content?.mimeType === 'video/mp4'">
-                <button [disabled]="!uploadVideoUrl && uploadFileName == '' || videoQuestions.length >= 4"
-                  class="add-video-question-btn margin-bottom-m text-white save-btn-bottom"
-                  (click)="addVideoQuestion()">Add
-                  Quiz</button>
-              </div>
-
-              <ng-container *ngTemplateOutlet="videoQuizFormTpl; context: { useResourceSave: true }"></ng-container>
-
-            </form>
-          </div>
-        </div>
-        <!--Resource types page -->
-        <div class="mc-resource-type-panel" *ngIf="isResourceTypeEnabled && showAddModuleForm">
-          <!-- Header: mc-card-header pattern -->
-          <div class="mc-card-header mc-resource-type-header">
-            <div class="mc-card-icon">
-              <mat-icon>perm_media</mat-icon>
-            </div>
-            <div class="mc-card-meta">
-              <span class="mc-card-title">Select Resource Type</span>
-              <span class="mc-card-sub">Choose the format for your resource content</span>
-            </div>
-            <button mat-stroked-button class="mc-cancel-resource-btn" (click)="cancelResouceSelection()">
-              Cancel
-            </button>
-          </div>
-
-          <!-- Content type grid -->
-          <div class="mc-resource-type-body">
-            <ng-container *ngIf="!isSelfAssessment">
-              <p class="mc-section-label">Learning Format</p>
-              <div class="mc-format-grid">
-                <div class="mc-format-item" *ngFor="let list of contentList; trackBy: trackByIndex"
-                  (click)="createResourseContent(list.name, list.type)" role="button" tabindex="0">
-                  <div class="mc-format-icon-box">
-                    <img loading="lazy" [src]="list.icon" [alt]="list.name" />
-                  </div>
-                  <span class="mc-format-label">{{list.name}}</span>
+                  <input
+                    matInput
+                    class="numberInput"
+                    [(ngModel)]="seconds"
+                    [ngModelOptions]="{ standalone: true }"
+                    (keyup)="this.resourcePdfForm.controls.duration.setValue(this.timeToSeconds())"
+                    placeholder="ss"
+                    type="number"
+                    min="0"
+                    max="59"
+                    step="1"
+                    onkeydown="
+                      javascript: return ['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight'].includes(event.code)
+                        ? true
+                        : !isNaN(Number(event.key)) && event.code !== 'Space'
+                    "
+                  />
                 </div>
-              </div>
-            </ng-container>
-
-            <p class="mc-section-label">Assess your Learners</p>
-            <div class="mc-assess-grid">
-              <div class="mc-assess-item" *ngFor="let list of accessList; trackBy: trackByIndex"
-                (click)="createResourseContent(list.name, list.type)" role="button" tabindex="0">
-                <div class="mc-assess-item-inner">
-                  <div class="mc-format-icon-box">
-                    <img loading="lazy" [src]="list.icon" [alt]="list.name" />
-                  </div>
-                  <span class="mc-format-label">{{list.name}}</span>
+                <span *ngIf="resourcePdfForm.get('duration').hasError('required')" class="module-txt-block invalid-text"
+                  >This field is Required</span
+                >
+                <div class="module-txt-block margin-top-m" *ngIf="content?.mimeType === 'video/mp4'">
+                  <span
+                    [ngClass]="{ 'disabled-text': (!uploadVideoUrl && uploadFileName == '') || videoQuestions.length >= 4 }"
+                    class="video-quiz-text"
+                    >Add In-video Quiz</span
+                  >
                 </div>
-                <p class="mc-assess-help">{{list.text}}</p>
-              </div>
+                <div class="module-txt-block margin-top-xs" *ngIf="content?.mimeType === 'video/mp4'">
+                  <button
+                    [disabled]="(!uploadVideoUrl && uploadFileName == '') || videoQuestions.length >= 4"
+                    class="add-video-question-btn margin-bottom-m text-white save-btn-bottom"
+                    (click)="addVideoQuestion()"
+                  >
+                    Add Quiz
+                  </button>
+                </div>
+
+                <ng-container *ngTemplateOutlet="videoQuizFormTpl; context: { useResourceSave: true }"></ng-container>
+              </form>
             </div>
           </div>
-        </div>
-
-        <!-- ── Shared template: assessment/quiz "save before adding questions" warning ── -->
-        <ng-template #assessmentWarningTpl>
-          <div class="flex items-center gap-2">
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="15" viewBox="0 0 16 15" fill="none">
-              <g clip-path="url(#clip0_warn)">
-                <path d="M7.9936 14.9957C5.80575 14.9957 3.61362 14.9957 1.42577 14.9957C0.637968 14.9957 0.0685271 14.5064 0.00430449 13.7808C-0.0213846 13.4686 0.0770902 13.1943 0.235506 12.9286C1.39579 10.95 2.55608 8.97138 3.71637 6.98858C4.75678 5.21249 5.79719 3.4364 6.84187 1.66031C7.15442 1.13296 7.69818 0.888275 8.28903 1.01484C8.69577 1.09921 8.98263 1.33968 9.18814 1.69405C10.5497 4.02702 11.9155 6.35576 13.2813 8.68451C14.1162 10.1062 14.9468 11.5279 15.7817 12.9497C16.3597 13.9368 15.7389 14.9957 14.5786 14.9957C12.3821 14.9957 10.1857 14.9957 7.98932 14.9957H7.9936ZM7.9936 13.9537C10.1686 13.9537 12.3436 13.9537 14.5186 13.9537C14.9468 13.9537 15.0538 13.7808 14.844 13.4264C12.6604 9.70123 10.4769 5.97186 8.29331 2.24671C8.12205 1.9514 7.90797 1.9514 7.72815 2.24249C7.70674 2.27624 7.68961 2.30999 7.66821 2.34374C5.93848 5.29686 4.20875 8.2542 2.47474 11.2073C2.02518 11.9751 1.57562 12.7387 1.12606 13.5065C0.98477 13.7512 1.10037 13.9453 1.38723 13.9537C1.43861 13.9537 1.49427 13.9537 1.54565 13.9537C3.69497 13.9537 5.84428 13.9537 7.9936 13.9537Z" fill="black"/>
-                <path d="M7.98926 13.9538C5.83994 13.9538 3.69063 13.9538 1.54131 13.9538C1.48993 13.9538 1.43427 13.9538 1.38289 13.9538C1.09603 13.9453 0.980432 13.7513 1.12172 13.5066C1.567 12.7388 2.02084 11.971 2.4704 11.2074C4.20013 8.25426 5.92986 5.29692 7.66387 2.3438C7.68527 2.31005 7.7024 2.2763 7.72381 2.24255C7.89935 1.95568 8.11771 1.95568 8.28897 2.24677C10.4725 5.97192 12.6561 9.70129 14.8397 13.4264C15.0495 13.785 14.9424 13.9538 14.5143 13.9538C12.3393 13.9538 10.1643 13.9538 7.98926 13.9538ZM7.23143 5.97192C7.33419 7.01395 7.43695 8.07286 7.54399 9.13598C7.57824 9.4777 7.60821 9.82363 7.65102 10.1654C7.67671 10.3636 7.82656 10.4986 8.00211 10.5029C8.18193 10.5029 8.3275 10.3763 8.36175 10.178C8.3746 10.1063 8.38316 10.0346 8.38744 9.96285C8.51589 8.6677 8.64433 7.37254 8.7685 6.07739C8.78134 5.94239 8.78134 5.80317 8.76421 5.66817C8.69999 5.19989 8.43454 4.98474 7.95501 5.00161C7.53542 5.01427 7.28281 5.26739 7.24856 5.71458C7.24428 5.79052 7.24 5.87067 7.23572 5.97192H7.23143ZM8.7685 11.9668C8.7685 11.5407 8.41741 11.1947 7.98498 11.1947C7.55683 11.1947 7.20146 11.5491 7.20575 11.9668C7.20575 12.3928 7.55683 12.7346 7.98926 12.7346C8.42169 12.7346 8.77278 12.3886 8.7685 11.9625V11.9668Z" fill="#F9F487"/>
-                <path d="M7.23145 5.9719C7.23574 5.87065 7.23574 5.79471 7.2443 5.71456C7.28283 5.26737 7.53116 5.01425 7.95075 5.00159C8.43028 4.98472 8.69573 5.19987 8.75995 5.66815C8.77708 5.80315 8.77708 5.94237 8.76423 6.07737C8.64007 7.37252 8.51163 8.66768 8.38318 9.96283C8.37462 10.0345 8.37034 10.1063 8.35749 10.178C8.32324 10.3763 8.17767 10.507 7.99784 10.5028C7.8223 10.5028 7.67245 10.3678 7.64676 10.1653C7.60395 9.82361 7.57398 9.47768 7.53972 9.13596C7.43269 8.07283 7.32993 7.01393 7.22717 5.9719H7.23145Z" fill="black"/>
-                <path d="M8.76856 11.9667C8.76856 12.3886 8.42176 12.7388 7.98933 12.7388C7.55689 12.7388 7.21009 12.397 7.20581 11.9709C7.20581 11.5491 7.55689 11.1989 7.98505 11.1989C8.4132 11.1989 8.76428 11.5449 8.76856 11.9709V11.9667Z" fill="black"/>
-              </g>
-              <defs>
-                <clipPath id="clip0_warn">
-                  <rect width="16" height="14.0147" fill="white" transform="translate(0 0.985352)" />
-                </clipPath>
-              </defs>
-            </svg>
-            <span class="quiz-help-txt" style="margin-left: 5px;">Save the {{content?.isAssessment?'Assessment':'Quiz'}} details before clicking on add Questions</span>
-          </div>
-        </ng-template>
-
-        <!-- ── Shared template: in-video quiz form ── -->
-        <!-- Context: { useResourceSave: boolean } -->
-        <!-- useResourceSave=true  → Save calls resourcePdfSave() (PDF/resource form context) -->
-        <!-- useResourceSave=false → Save calls saveDetails()     (module form context)       -->
-        <ng-template #videoQuizFormTpl let-useResourceSave="useResourceSave">
-          <div *ngIf="showQuizForm" class="module-txt-block quiz-form">
-            <div class="tabs">
-              <div *ngFor="let question of videoQuestions; let i = index; trackBy: trackByIndex" class="tab"
-                [ngClass]="{'active-tab': i === activeTabIndex}" (click)="setActiveTab(i)"
-                (keydown)="handleKeyDown($event, i)">
-                Question {{i + 1}}
-                <img *ngIf="videoQuestions.length > 0 && i === activeTabIndex" class="ml-2" loading="lazy"
-                  (click)="deleteQuestion(i)" (keydown)="deleteQuestion(activeTabIndex)"
-                  src="cbp-assets/icons/bin.svg" alt="delete-icon">
+          <!--Resource types page -->
+          <div class="mc-resource-type-panel" *ngIf="isResourceTypeEnabled && showAddModuleForm">
+            <!-- Header: mc-card-header pattern -->
+            <div class="mc-card-header mc-resource-type-header">
+              <div class="mc-card-icon">
+                <mat-icon>perm_media</mat-icon>
               </div>
+              <div class="mc-card-meta">
+                <span class="mc-card-title">Select Resource Type</span>
+                <span class="mc-card-sub">Choose the format for your resource content</span>
+              </div>
+              <button mat-stroked-button class="mc-cancel-resource-btn" (click)="cancelResouceSelection()">Cancel</button>
             </div>
-            <div *ngFor="let question of videoQuestions; let i = index; trackBy: trackByIndex" class="question-form"
-              [ngClass]="{'active-form': i === activeTabIndex}">
-              <div class="duration-style margin-bottom-s timestamp">
-                <span class="timestamp-text">Timestamp:</span>
-                <input matInput class="numberInput" id="timestamp" type="number"
-                  [(ngModel)]="question.timestamp.hours" [ngModelOptions]="{standalone: true}"
-                  placeholder="hh" min="0" max="12" step="1" (ngModelChange)="updateTimestampInSeconds(i)">
-                <div class="colon-block">:</div>
-                <input matInput class="numberInput" type="number"
-                  [(ngModel)]="question.timestamp.minutes" [ngModelOptions]="{standalone: true}"
-                  placeholder="mm" min="0" max="59" step="1" (ngModelChange)="updateTimestampInSeconds(i)">
-                <div class="colon-block">:</div>
-                <input matInput class="numberInput" type="number"
-                  [(ngModel)]="question.timestamp.seconds" [ngModelOptions]="{standalone: true}"
-                  placeholder="ss" min="1" max="59" step="1" (ngModelChange)="updateTimestampInSeconds(i)">
-              </div>
-              <span class="invalid-text timestamp-error" *ngIf="isTimestampBeyondVideo(question)">
-                Timestamp must be within the video length ({{ videoActualDuration | formatDuration }}).
-                The quiz won't appear after the video ends.
-              </span>
-              <div class="mb-2" *ngFor="let subQuestion of question.question; let j = index; trackBy: trackByIndex">
-                <div class="question">
-                  <textarea rows="2" matInput [(ngModel)]="subQuestion.text"
-                    [ngModelOptions]="{standalone: true}" class="module-input question-text margin-top-s"
-                    placeholder="Question" autocomplete="off" maxlength="100"></textarea><br>
-                  <mat-hint class="mt-hint">{{ subQuestion.text.length }}/100</mat-hint><br>
-                </div>
-                <div class="flex flex-direction-column mb-2">
-                  <div class="options-header">
-                    <span class="video-quiz-text">Options</span>
-                  </div>
-                  <div class="options-note-container">
-                    <span class="options-note">Note: Check the correct answer circle only. Add notes to explain in
-                      the text field next to it.</span>
-                  </div>
-                </div>
-                <div class="mt-1 option-block" *ngFor="let option of subQuestion.options; let k = index; trackBy: trackByIndex">
-                  <div class="input-container">
-                    <div class="option-container">
-                      <input type="radio" name="isCorrect-{{i}}-{{j}}" [checked]="option.isCorrect"
-                        (click)="setCorrectOption(i, j, k)" class="radio-button">
-                      <input class="option-input" matInput type="text" [(ngModel)]="option.text"
-                        [ngModelOptions]="{standalone: true}" placeholder="Add Option"
-                        autocomplete="off" maxlength="30">
-                      <img loading="lazy" (click)="deleteOption(i, j, k)"
-                        src="cbp-assets/icons/fluent_delete-24-regular.svg" alt="delete-icon"
-                        class="option-delete-icon">
+
+            <!-- Content type grid -->
+            <div class="mc-resource-type-body">
+              <ng-container *ngIf="!isSelfAssessment">
+                <p class="mc-section-label">Learning Format</p>
+                <div class="mc-format-grid">
+                  <div
+                    class="mc-format-item"
+                    *ngFor="let list of contentList; trackBy: trackByIndex"
+                    (click)="createResourseContent(list.name, list.type)"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <div class="mc-format-icon-box">
+                      <img loading="lazy" [src]="list.icon" [alt]="list.name" />
                     </div>
-                    <mat-hint class="mt-hint">{{ option.text.length }}/30</mat-hint>
-                  </div>
-                  <div class="answer-info-container">
-                    <input class="option-input option-answerinfo-input pl-0" matInput type="text"
-                      [(ngModel)]="option.answerInfo" [ngModelOptions]="{standalone: true}"
-                      placeholder="Add Note" autocomplete="off" maxlength="80">
-                    <mat-hint class="mt-hint">{{ option.answerInfo.length }}/80</mat-hint>
+                    <span class="mc-format-label">{{ list.name }}</span>
                   </div>
                 </div>
-                <button *ngIf="subQuestion.options.length < 4" class="add-option-btn"
-                  (click)="addOption(i, j)" [disabled]="subQuestion.options.length >= 4">
-                  <img class="delete-icon" loading="lazy"
-                    src="cbp-assets/icons/ant-design_plus-circle-outlined.svg" alt="add option" />
-                  Add Option
+              </ng-container>
+
+              <p class="mc-section-label">Assess your Learners</p>
+              <div class="mc-assess-grid">
+                <div
+                  class="mc-assess-item"
+                  *ngFor="let list of accessList; trackBy: trackByIndex"
+                  (click)="createResourseContent(list.name, list.type)"
+                  role="button"
+                  tabindex="0"
+                >
+                  <div class="mc-assess-item-inner">
+                    <div class="mc-format-icon-box">
+                      <img loading="lazy" [src]="list.icon" [alt]="list.name" />
+                    </div>
+                    <span class="mc-format-label">{{ list.name }}</span>
+                  </div>
+                  <p class="mc-assess-help">{{ list.text }}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- ── Shared template: assessment/quiz "save before adding questions" warning ── -->
+          <ng-template #assessmentWarningTpl>
+            <div class="flex items-center gap-2">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="15" viewBox="0 0 16 15" fill="none">
+                <g clip-path="url(#clip0_warn)">
+                  <path
+                    d="M7.9936 14.9957C5.80575 14.9957 3.61362 14.9957 1.42577 14.9957C0.637968 14.9957 0.0685271 14.5064 0.00430449 13.7808C-0.0213846 13.4686 0.0770902 13.1943 0.235506 12.9286C1.39579 10.95 2.55608 8.97138 3.71637 6.98858C4.75678 5.21249 5.79719 3.4364 6.84187 1.66031C7.15442 1.13296 7.69818 0.888275 8.28903 1.01484C8.69577 1.09921 8.98263 1.33968 9.18814 1.69405C10.5497 4.02702 11.9155 6.35576 13.2813 8.68451C14.1162 10.1062 14.9468 11.5279 15.7817 12.9497C16.3597 13.9368 15.7389 14.9957 14.5786 14.9957C12.3821 14.9957 10.1857 14.9957 7.98932 14.9957H7.9936ZM7.9936 13.9537C10.1686 13.9537 12.3436 13.9537 14.5186 13.9537C14.9468 13.9537 15.0538 13.7808 14.844 13.4264C12.6604 9.70123 10.4769 5.97186 8.29331 2.24671C8.12205 1.9514 7.90797 1.9514 7.72815 2.24249C7.70674 2.27624 7.68961 2.30999 7.66821 2.34374C5.93848 5.29686 4.20875 8.2542 2.47474 11.2073C2.02518 11.9751 1.57562 12.7387 1.12606 13.5065C0.98477 13.7512 1.10037 13.9453 1.38723 13.9537C1.43861 13.9537 1.49427 13.9537 1.54565 13.9537C3.69497 13.9537 5.84428 13.9537 7.9936 13.9537Z"
+                    fill="black"
+                  />
+                  <path
+                    d="M7.98926 13.9538C5.83994 13.9538 3.69063 13.9538 1.54131 13.9538C1.48993 13.9538 1.43427 13.9538 1.38289 13.9538C1.09603 13.9453 0.980432 13.7513 1.12172 13.5066C1.567 12.7388 2.02084 11.971 2.4704 11.2074C4.20013 8.25426 5.92986 5.29692 7.66387 2.3438C7.68527 2.31005 7.7024 2.2763 7.72381 2.24255C7.89935 1.95568 8.11771 1.95568 8.28897 2.24677C10.4725 5.97192 12.6561 9.70129 14.8397 13.4264C15.0495 13.785 14.9424 13.9538 14.5143 13.9538C12.3393 13.9538 10.1643 13.9538 7.98926 13.9538ZM7.23143 5.97192C7.33419 7.01395 7.43695 8.07286 7.54399 9.13598C7.57824 9.4777 7.60821 9.82363 7.65102 10.1654C7.67671 10.3636 7.82656 10.4986 8.00211 10.5029C8.18193 10.5029 8.3275 10.3763 8.36175 10.178C8.3746 10.1063 8.38316 10.0346 8.38744 9.96285C8.51589 8.6677 8.64433 7.37254 8.7685 6.07739C8.78134 5.94239 8.78134 5.80317 8.76421 5.66817C8.69999 5.19989 8.43454 4.98474 7.95501 5.00161C7.53542 5.01427 7.28281 5.26739 7.24856 5.71458C7.24428 5.79052 7.24 5.87067 7.23572 5.97192H7.23143ZM8.7685 11.9668C8.7685 11.5407 8.41741 11.1947 7.98498 11.1947C7.55683 11.1947 7.20146 11.5491 7.20575 11.9668C7.20575 12.3928 7.55683 12.7346 7.98926 12.7346C8.42169 12.7346 8.77278 12.3886 8.7685 11.9625V11.9668Z"
+                    fill="#F9F487"
+                  />
+                  <path
+                    d="M7.23145 5.9719C7.23574 5.87065 7.23574 5.79471 7.2443 5.71456C7.28283 5.26737 7.53116 5.01425 7.95075 5.00159C8.43028 4.98472 8.69573 5.19987 8.75995 5.66815C8.77708 5.80315 8.77708 5.94237 8.76423 6.07737C8.64007 7.37252 8.51163 8.66768 8.38318 9.96283C8.37462 10.0345 8.37034 10.1063 8.35749 10.178C8.32324 10.3763 8.17767 10.507 7.99784 10.5028C7.8223 10.5028 7.67245 10.3678 7.64676 10.1653C7.60395 9.82361 7.57398 9.47768 7.53972 9.13596C7.43269 8.07283 7.32993 7.01393 7.22717 5.9719H7.23145Z"
+                    fill="black"
+                  />
+                  <path
+                    d="M8.76856 11.9667C8.76856 12.3886 8.42176 12.7388 7.98933 12.7388C7.55689 12.7388 7.21009 12.397 7.20581 11.9709C7.20581 11.5491 7.55689 11.1989 7.98505 11.1989C8.4132 11.1989 8.76428 11.5449 8.76856 11.9709V11.9667Z"
+                    fill="black"
+                  />
+                </g>
+                <defs>
+                  <clipPath id="clip0_warn">
+                    <rect width="16" height="14.0147" fill="white" transform="translate(0 0.985352)" />
+                  </clipPath>
+                </defs>
+              </svg>
+              <span class="quiz-help-txt" style="margin-left: 5px"
+                >Save the {{ content?.isAssessment ? 'Assessment' : 'Quiz' }} details before clicking on add Questions</span
+              >
+            </div>
+          </ng-template>
+
+          <!-- ── Shared template: in-video quiz form ── -->
+          <!-- Context: { useResourceSave: boolean } -->
+          <!-- useResourceSave=true  → Save calls resourcePdfSave() (PDF/resource form context) -->
+          <!-- useResourceSave=false → Save calls saveDetails()     (module form context)       -->
+          <ng-template #videoQuizFormTpl let-useResourceSave="useResourceSave">
+            <div *ngIf="showQuizForm" class="module-txt-block quiz-form">
+              <div class="tabs">
+                <div
+                  *ngFor="let question of videoQuestions; let i = index; trackBy: trackByIndex"
+                  class="tab"
+                  [ngClass]="{ 'active-tab': i === activeTabIndex }"
+                  (click)="setActiveTab(i)"
+                  (keydown)="handleKeyDown($event, i)"
+                >
+                  Question {{ i + 1 }}
+                  <img
+                    *ngIf="videoQuestions.length > 0 && i === activeTabIndex"
+                    class="ml-2"
+                    loading="lazy"
+                    (click)="deleteQuestion(i)"
+                    (keydown)="deleteQuestion(activeTabIndex)"
+                    src="cbp-assets/icons/bin.svg"
+                    alt="delete-icon"
+                  />
+                </div>
+              </div>
+              <div
+                *ngFor="let question of videoQuestions; let i = index; trackBy: trackByIndex"
+                class="question-form"
+                [ngClass]="{ 'active-form': i === activeTabIndex }"
+              >
+                <div class="duration-style margin-bottom-s timestamp">
+                  <span class="timestamp-text">Timestamp:</span>
+                  <input
+                    matInput
+                    class="numberInput"
+                    id="timestamp"
+                    type="number"
+                    [(ngModel)]="question.timestamp.hours"
+                    [ngModelOptions]="{ standalone: true }"
+                    placeholder="hh"
+                    min="0"
+                    max="12"
+                    step="1"
+                    (ngModelChange)="updateTimestampInSeconds(i)"
+                  />
+                  <div class="colon-block">:</div>
+                  <input
+                    matInput
+                    class="numberInput"
+                    type="number"
+                    [(ngModel)]="question.timestamp.minutes"
+                    [ngModelOptions]="{ standalone: true }"
+                    placeholder="mm"
+                    min="0"
+                    max="59"
+                    step="1"
+                    (ngModelChange)="updateTimestampInSeconds(i)"
+                  />
+                  <div class="colon-block">:</div>
+                  <input
+                    matInput
+                    class="numberInput"
+                    type="number"
+                    [(ngModel)]="question.timestamp.seconds"
+                    [ngModelOptions]="{ standalone: true }"
+                    placeholder="ss"
+                    min="1"
+                    max="59"
+                    step="1"
+                    (ngModelChange)="updateTimestampInSeconds(i)"
+                  />
+                </div>
+                <span class="invalid-text timestamp-error" *ngIf="isTimestampBeyondVideo(question)">
+                  Timestamp must be within the video length ({{ videoActualDuration | formatDuration }}). The quiz won't appear after the
+                  video ends.
+                </span>
+                <div class="mb-2" *ngFor="let subQuestion of question.question; let j = index; trackBy: trackByIndex">
+                  <div class="question">
+                    <textarea
+                      rows="2"
+                      matInput
+                      [(ngModel)]="subQuestion.text"
+                      [ngModelOptions]="{ standalone: true }"
+                      class="module-input question-text margin-top-s"
+                      placeholder="Question"
+                      autocomplete="off"
+                      maxlength="100"
+                    ></textarea
+                    ><br />
+                    <mat-hint class="mt-hint">{{ subQuestion.text.length }}/100</mat-hint><br />
+                  </div>
+                  <div class="flex flex-direction-column mb-2">
+                    <div class="options-header">
+                      <span class="video-quiz-text">Options</span>
+                    </div>
+                    <div class="options-note-container">
+                      <span class="options-note"
+                        >Note: Check the correct answer circle only. Add notes to explain in the text field next to it.</span
+                      >
+                    </div>
+                  </div>
+                  <div class="mt-1 option-block" *ngFor="let option of subQuestion.options; let k = index; trackBy: trackByIndex">
+                    <div class="input-container">
+                      <div class="option-container">
+                        <input
+                          type="radio"
+                          name="isCorrect-{{ i }}-{{ j }}"
+                          [checked]="option.isCorrect"
+                          (click)="setCorrectOption(i, j, k)"
+                          class="radio-button"
+                        />
+                        <input
+                          class="option-input"
+                          matInput
+                          type="text"
+                          [(ngModel)]="option.text"
+                          [ngModelOptions]="{ standalone: true }"
+                          placeholder="Add Option"
+                          autocomplete="off"
+                          maxlength="30"
+                        />
+                        <img
+                          loading="lazy"
+                          (click)="deleteOption(i, j, k)"
+                          src="cbp-assets/icons/fluent_delete-24-regular.svg"
+                          alt="delete-icon"
+                          class="option-delete-icon"
+                        />
+                      </div>
+                      <mat-hint class="mt-hint">{{ option.text.length }}/30</mat-hint>
+                    </div>
+                    <div class="answer-info-container">
+                      <input
+                        class="option-input option-answerinfo-input pl-0"
+                        matInput
+                        type="text"
+                        [(ngModel)]="option.answerInfo"
+                        [ngModelOptions]="{ standalone: true }"
+                        placeholder="Add Note"
+                        autocomplete="off"
+                        maxlength="80"
+                      />
+                      <mat-hint class="mt-hint">{{ option.answerInfo.length }}/80</mat-hint>
+                    </div>
+                  </div>
+                  <button
+                    *ngIf="subQuestion.options.length < 4"
+                    class="add-option-btn"
+                    (click)="addOption(i, j)"
+                    [disabled]="subQuestion.options.length >= 4"
+                  >
+                    <img class="delete-icon" loading="lazy" src="cbp-assets/icons/ant-design_plus-circle-outlined.svg" alt="add option" />
+                    Add Option
+                  </button>
+                  <ng-container *ngIf="useResourceSave; else mainQuizSaveBtn">
+                    <div *ngIf="isPdfOrAudioOrVedioEnabled">
+                      <button
+                        [disabled]="uploadFileName === '' || hasTimestampBeyondVideo"
+                        mat-raised-button
+                        class="width-15 mb-2 text-white mat-button-base save-btn-bottom resourcePdfSave"
+                        (click)="resourcePdfSave()"
+                      >
+                        Save
+                      </button>
+                    </div>
+                  </ng-container>
+                  <ng-template #mainQuizSaveBtn>
+                    <button
+                      [disabled]="(uploadFileName ? uploadFileName === '' : true) || hasTimestampBeyondVideo"
+                      mat-raised-button
+                      *ngIf="
+                        moduleButtonName === 'Save' &&
+                        content?.contentType !== 'Collection' &&
+                        content?.contentType !== 'CourseUnit' &&
+                        content?.contentType !== 'Course' &&
+                        !isLinkEnabled &&
+                        content?.mimeType !== 'application/json'
+                      "
+                      class="width-15 text-white mat-button-base save-btn-bottom resourcePdfSave"
+                      (click)="saveDetails(moduleName, topicDescription, thumbnail, isNewTab, isShowBtn, content?.mimeType)"
+                    >
+                      {{ moduleButtonName }}
+                    </button>
+                  </ng-template>
+                </div>
+              </div>
+            </div>
+          </ng-template>
+
+          <ng-template #guideline>
+            <div class="margin-top-m margin-bottom-m">
+              <div style="position: relative">
+                <h3 class="mat-h3 font-weight-bold margin-remove-bottom" i18n>Guidelines for zip file upload</h3>
+                <button class="close-button primary-button" (click)="closeDialog()">
+                  <mat-icon aria-label="Next" role="button">close</mat-icon>
                 </button>
-                <ng-container *ngIf="useResourceSave; else mainQuizSaveBtn">
-                  <div *ngIf="isPdfOrAudioOrVedioEnabled">
-                    <button [disabled]="uploadFileName === '' || hasTimestampBeyondVideo" mat-raised-button
-                      class="width-15 mb-2 text-white mat-button-base save-btn-bottom resourcePdfSave"
-                      (click)="resourcePdfSave()">Save</button>
-                  </div>
-                </ng-container>
-                <ng-template #mainQuizSaveBtn>
-                  <button [disabled]="(uploadFileName ? uploadFileName === '' : true) || hasTimestampBeyondVideo" mat-raised-button
-                    *ngIf="moduleButtonName === 'Save' && content?.contentType !== 'Collection' && content?.contentType !== 'CourseUnit' && content?.contentType !== 'Course' && !isLinkEnabled && content?.mimeType !== 'application/json'"
-                    class="width-15 text-white mat-button-base save-btn-bottom resourcePdfSave"
-                    (click)="saveDetails(moduleName, topicDescription, thumbnail, isNewTab, isShowBtn, content?.mimeType)">
-                    {{moduleButtonName}}</button>
-                </ng-template>
               </div>
-            </div>
-          </div>
-        </ng-template>
-
-        <ng-template #guideline>
-          <div class="margin-top-m margin-bottom-m">
-            <div style="position: relative;">
-              <h3 class="mat-h3 font-weight-bold margin-remove-bottom" i18n>
-                Guidelines for zip file upload
-              </h3>
-              <button class="close-button primary-button" (click)="closeDialog()">
-                <mat-icon aria-label="Next" role="button">close</mat-icon>
-              </button>
-            </div>
-            <div style="max-height: 400px">
-              <div class="mat-form-field mt-4">
-                <div class="flex w-100">
-                  <mat-checkbox [(ngModel)]="fileUploadCondition.fileName" i18n></mat-checkbox>
-                  <div class="margin-left-s" i18n>All the folder and file names should not contains any special
-                    character
-                    including space</div>
-                </div>
-                <div class="flex relative mat-form-field-appearance-fill mt-4"
-                  *ngIf="fileUploadCondition.isSubmitPressed && !fileUploadCondition.fileName">
-                  <div class="mat-form-field-subscript-wrapper mat-error no-padding" i18n>
-                    Accept the declaration
+              <div style="max-height: 400px">
+                <div class="mat-form-field mt-4">
+                  <div class="flex w-100">
+                    <mat-checkbox [(ngModel)]="fileUploadCondition.fileName" i18n></mat-checkbox>
+                    <div class="margin-left-s" i18n>
+                      All the folder and file names should not contains any special character including space
+                    </div>
+                  </div>
+                  <div
+                    class="flex relative mat-form-field-appearance-fill mt-4"
+                    *ngIf="fileUploadCondition.isSubmitPressed && !fileUploadCondition.fileName"
+                  >
+                    <div class="mat-form-field-subscript-wrapper mat-error no-padding" i18n>Accept the declaration</div>
                   </div>
                 </div>
-              </div>
-              <div class="mat-form-field mt-4">
-                <div class="flex w-100">
-                  <mat-checkbox [(ngModel)]="fileUploadCondition.eval" i18n></mat-checkbox>
-                  <div class="margin-left-s" i18n>Should not have any code which will cause security vulnerability like
-                    usage
-                    eval function</div>
-                </div>
-                <div class="flex relative mat-form-field-appearance-fill mt-4"
-                  *ngIf="fileUploadCondition.isSubmitPressed && !fileUploadCondition.eval">
-                  <div class="mat-form-field-subscript-wrapper mat-error no-padding" i18n>
-                    Accept the declaration
+                <div class="mat-form-field mt-4">
+                  <div class="flex w-100">
+                    <mat-checkbox [(ngModel)]="fileUploadCondition.eval" i18n></mat-checkbox>
+                    <div class="margin-left-s" i18n>
+                      Should not have any code which will cause security vulnerability like usage eval function
+                    </div>
+                  </div>
+                  <div
+                    class="flex relative mat-form-field-appearance-fill mt-4"
+                    *ngIf="fileUploadCondition.isSubmitPressed && !fileUploadCondition.eval"
+                  >
+                    <div class="mat-form-field-subscript-wrapper mat-error no-padding" i18n>Accept the declaration</div>
                   </div>
                 </div>
-              </div>
-              <div class="mat-form-field mt-4">
-                <div class="flex w-100">
-                  <mat-checkbox [(ngModel)]="fileUploadCondition.externalReference" i18n></mat-checkbox>
-                  <div class="margin-left-s" i18n>All the dependencies should be included in the zip. Should not refer
-                    to
-                    external
-                    websites to load any assets like images, css or js</div>
-                </div>
-                <div class="flex relative mat-form-field-appearance-fill mt-4"
-                  *ngIf="fileUploadCondition.isSubmitPressed && !fileUploadCondition.externalReference">
-                  <div class="mat-form-field-subscript-wrapper mat-error no-padding" i18n>
-                    Accept the declaration
+                <div class="mat-form-field mt-4">
+                  <div class="flex w-100">
+                    <mat-checkbox [(ngModel)]="fileUploadCondition.externalReference" i18n></mat-checkbox>
+                    <div class="margin-left-s" i18n>
+                      All the dependencies should be included in the zip. Should not refer to external websites to load any assets like
+                      images, css or js
+                    </div>
+                  </div>
+                  <div
+                    class="flex relative mat-form-field-appearance-fill mt-4"
+                    *ngIf="fileUploadCondition.isSubmitPressed && !fileUploadCondition.externalReference"
+                  >
+                    <div class="mat-form-field-subscript-wrapper mat-error no-padding" i18n>Accept the declaration</div>
                   </div>
                 </div>
-              </div>
-              <div class="mat-form-field mt-4">
-                <div class="flex w-100">
-                  <mat-checkbox [(ngModel)]="fileUploadCondition.iframe" i18n></mat-checkbox>
-                  <div class="margin-left-s" i18n>Should not include any iframe. If required contact the Platform Admin.
+                <div class="mat-form-field mt-4">
+                  <div class="flex w-100">
+                    <mat-checkbox [(ngModel)]="fileUploadCondition.iframe" i18n></mat-checkbox>
+                    <div class="margin-left-s" i18n>Should not include any iframe. If required contact the Platform Admin.</div>
+                  </div>
+                  <div
+                    class="flex relative mat-form-field-appearance-fill mt-4"
+                    *ngIf="fileUploadCondition.isSubmitPressed && !fileUploadCondition.iframe"
+                  >
+                    <div class="mat-form-field-subscript-wrapper mat-error no-padding" i18n>Accept the declaration</div>
                   </div>
                 </div>
-                <div class="flex relative mat-form-field-appearance-fill mt-4"
-                  *ngIf="fileUploadCondition.isSubmitPressed && !fileUploadCondition.iframe">
-                  <div class="mat-form-field-subscript-wrapper mat-error no-padding" i18n>
-                    Accept the declaration
+                <div class="mat-form-field mt-4">
+                  <div class="flex w-100">
+                    <mat-checkbox [(ngModel)]="fileUploadCondition.preview" i18n></mat-checkbox>
+                    <div class="margin-left-s" i18n>
+                      After successful upload of zip file ensure everything is working fine by previewing the content. If there is any
+                      inconsistency check in the developer mode to know the exact reason
+                    </div>
                   </div>
-                </div>
-              </div>
-              <div class="mat-form-field mt-4">
-                <div class="flex w-100">
-                  <mat-checkbox [(ngModel)]="fileUploadCondition.preview" i18n></mat-checkbox>
-                  <div class="margin-left-s" i18n>After successful upload of zip file ensure everything is working fine
-                    by
-                    previewing the content. If there is any inconsistency check in the developer mode to know the exact
-                    reason</div>
-                </div>
-                <div class="flex relative mat-form-field-appearance-fill mt-4"
-                  *ngIf="fileUploadCondition.isSubmitPressed && !fileUploadCondition.preview">
-                  <div class="mat-form-field-subscript-wrapper mat-error no-padding" i18n>
-                    Accept the declaration
+                  <div
+                    class="flex relative mat-form-field-appearance-fill mt-4"
+                    *ngIf="fileUploadCondition.isSubmitPressed && !fileUploadCondition.preview"
+                  >
+                    <div class="mat-form-field-subscript-wrapper mat-error no-padding" i18n>Accept the declaration</div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div class="flex justify-center ">
-            <button type="button" [disabled]="!fileUploadCondition.fileName ||
-                !fileUploadCondition.iframe ||
-                !fileUploadCondition.eval ||
-                !fileUploadCondition.preview ||
-                !fileUploadCondition.externalReference" mat-raised-button
-              class="margin-top-m ws-mat-primary-background zip-upload-agree" (click)="fileUploadCondition.isSubmitPressed = true;
-                fileUploadCondition.fileName &&
-                fileUploadCondition.iframe &&
-                fileUploadCondition.eval &&
-                fileUploadCondition.preview &&
-                fileUploadCondition.externalReference ? closeDialog() : null">
-              <div class="flex flex-middle justify-center ">
-                <p class="margin-remove-bottom agree-text" i18n>I Agree</p>
-              </div>
-            </button>
-          </div>
-        </ng-template>
-        <ng-template #selectFile>
-          <div class="margin-top-m margin-bottom-m" style="max-height: 400px;">
-            <div style="position: relative;">
-              <h3 class="mat-h3 font-weight-bold margin-remove-bottom" i18n>
-                Select the entry file
-              </h3>
-              <button class="close-button primary-button" (click)="closeDialog()">
-                <mat-icon aria-label="Next" role="button">close</mat-icon>
-              </button>
-            </div>
-            <div class="mt-4">
-              <mat-radio-group aria-labelledby="example-radio-group-label"
-                class="flex flex-1 flex-column example-radio-group" [(ngModel)]="fileUploadCondition.url">
-                <mat-radio-button class="example-radio-button" *ngFor="let file of fileList; trackBy: trackByIndex" [value]="file"
-                  (change)="selectEntryPoint(file)">
-                  {{file}}
-                </mat-radio-button>
-              </mat-radio-group>
-            </div>
-            <div class="flex justify-center padding-bottom-m">
-              <button type="button" mat-raised-button color="primary" class="margin-top-m ws-mat-primary-background"
-                (click)="closeDialog(); selectedEntryFile=true">
+            <div class="flex justify-center">
+              <button
+                type="button"
+                [disabled]="
+                  !fileUploadCondition.fileName ||
+                  !fileUploadCondition.iframe ||
+                  !fileUploadCondition.eval ||
+                  !fileUploadCondition.preview ||
+                  !fileUploadCondition.externalReference
+                "
+                mat-raised-button
+                class="margin-top-m ws-mat-primary-background zip-upload-agree"
+                (click)="
+                  fileUploadCondition.isSubmitPressed = true;
+                  fileUploadCondition.fileName &&
+                  fileUploadCondition.iframe &&
+                  fileUploadCondition.eval &&
+                  fileUploadCondition.preview &&
+                  fileUploadCondition.externalReference
+                    ? closeDialog()
+                    : null
+                "
+              >
                 <div class="flex flex-middle justify-center">
-                  <p class="margin-remove-bottom agree-text" i18n>Done</p>
+                  <p class="margin-remove-bottom agree-text" i18n>I Agree</p>
                 </div>
               </button>
             </div>
-          </div>
-
-        </ng-template>
-        <ng-template #errorFile>
-          <div class="margin-top-m margin-bottom-m">
-            <div style="position: relative;">
-              <h3 class="mat-h3 font-weight-bold margin-remove-bottom" i18n>
-                Following files or folders have special characters in their names
-              </h3>
-              <button class="close-button primary-button" (click)="closeDialog()">
-                <mat-icon aria-label="Next" role="button">close</mat-icon>
+          </ng-template>
+          <ng-template #selectFile>
+            <div class="margin-top-m margin-bottom-m" style="max-height: 400px">
+              <div style="position: relative">
+                <h3 class="mat-h3 font-weight-bold margin-remove-bottom" i18n>Select the entry file</h3>
+                <button class="close-button primary-button" (click)="closeDialog()">
+                  <mat-icon aria-label="Next" role="button">close</mat-icon>
+                </button>
+              </div>
+              <div class="mt-4">
+                <mat-radio-group
+                  aria-labelledby="example-radio-group-label"
+                  class="flex flex-1 flex-column example-radio-group"
+                  [(ngModel)]="fileUploadCondition.url"
+                >
+                  <mat-radio-button
+                    class="example-radio-button"
+                    *ngFor="let file of fileList; trackBy: trackByIndex"
+                    [value]="file"
+                    (change)="selectEntryPoint(file)"
+                  >
+                    {{ file }}
+                  </mat-radio-button>
+                </mat-radio-group>
+              </div>
+              <div class="flex justify-center padding-bottom-m">
+                <button
+                  type="button"
+                  mat-raised-button
+                  color="primary"
+                  class="margin-top-m ws-mat-primary-background"
+                  (click)="closeDialog(); selectedEntryFile = true"
+                >
+                  <div class="flex flex-middle justify-center">
+                    <p class="margin-remove-bottom agree-text" i18n>Done</p>
+                  </div>
+                </button>
+              </div>
+            </div>
+          </ng-template>
+          <ng-template #errorFile>
+            <div class="margin-top-m margin-bottom-m">
+              <div style="position: relative">
+                <h3 class="mat-h3 font-weight-bold margin-remove-bottom" i18n>
+                  Following files or folders have special characters in their names
+                </h3>
+                <button class="close-button primary-button" (click)="closeDialog()">
+                  <mat-icon aria-label="Next" role="button">close</mat-icon>
+                </button>
+              </div>
+              <div style="max-height: 400px" class="mat-form-field mt-4" id="errorFiles">
+                <div *ngFor="let name of errorFileList; trackBy: trackByIndex">{{ name }}</div>
+              </div>
+            </div>
+            <div class="flex justify-center">
+              <button type="button" mat-raised-button class="ws-mat-primary-background margin-top-m" (click)="closeDialog()">
+                <div class="flex flex-middle justify-center">
+                  <p class="margin-remove-bottom agree-text" i18n>I Understand</p>
+                </div>
               </button>
             </div>
-            <div style="max-height: 400px" class="mat-form-field mt-4" id="errorFiles">
-              <div *ngFor="let name of errorFileList; trackBy: trackByIndex">{{name}}</div>
-            </div>
-          </div>
-          <div class="flex justify-center">
-            <button type="button" mat-raised-button class="ws-mat-primary-background margin-top-m"
-              (click)="closeDialog()">
-              <div class="flex flex-middle justify-center">
-                <p class="margin-remove-bottom agree-text" i18n>I Understand</p>
-              </div>
-            </button>
-          </div>
-        </ng-template>
-      </mat-drawer-container>
-      </div><!-- /mc-right-col -->
-    </div><!-- /mc-builder -->
-
-  </div><!-- /mc-builder-wrap -->
-  <ws-auth-course-settings (data)="action($event)" *ngIf="isSettingsPage" [triggerNext]="triggerCourseSettingsNext"
-    (validityChange)="settingsValidityChange.emit($event)"></ws-auth-course-settings>
+          </ng-template>
+        </mat-drawer-container>
+      </div>
+      <!-- /mc-right-col -->
+    </div>
+    <!-- /mc-builder -->
+  </div>
+  <!-- /mc-builder-wrap -->
+  <ws-auth-course-settings
+    (data)="action($event)"
+    *ngIf="isSettingsPage"
+    [triggerNext]="triggerCourseSettingsNext"
+    (validityChange)="settingsValidityChange.emit($event)"
+  ></ws-auth-course-settings>
 </div>

--- a/project/ws/author/src/lib/routing/modules/editor/routing/modules/collection/components/collection/module-creation/module-creation.component.spec.ts
+++ b/project/ws/author/src/lib/routing/modules/editor/routing/modules/collection/components/collection/module-creation/module-creation.component.spec.ts
@@ -62,7 +62,6 @@ import { Subject, of, BehaviorSubject } from 'rxjs'
 
 import { ZipJSResolverService } from '../../../../../../../../../../../../author/src/lib/services/zip-js-resolve.service'
 
-
 describe('ModuleCreationComponent without extractFile()', () => {
   let component: ModuleCreationComponent
   let fixture: ComponentFixture<ModuleCreationComponent>
@@ -74,12 +73,7 @@ describe('ModuleCreationComponent without extractFile()', () => {
     }
 
     await TestBed.configureTestingModule({
-      declarations: [
-        ModuleCreationComponent,
-        CourseSettingsComponent,
-        FormatDurationPipe,
-        MimeTypePipe,
-      ],
+      declarations: [ModuleCreationComponent, CourseSettingsComponent, FormatDurationPipe, MimeTypePipe],
       imports: [
         BrowserAnimationsModule,
         MatGridListModule,
@@ -97,12 +91,15 @@ describe('ModuleCreationComponent without extractFile()', () => {
         MatAutocompleteModule,
         MatSelectModule,
         RouterModule,
-        HttpClientTestingModule
+        HttpClientTestingModule,
       ],
       providers: [
         { provide: EditorContentService, useValue: mockContentService },
         { provide: APP_BASE_HREF, useValue: '/' },
-        { provide: AuthInitService, useValue: { backToHomeMessage: new Subject<any>(), changeActiveCont: of({}), updateResourceMessage: new Subject<any>() } },
+        {
+          provide: AuthInitService,
+          useValue: { backToHomeMessage: new Subject<any>(), changeActiveCont: of({}), updateResourceMessage: new Subject<any>() },
+        },
         { provide: Router, useValue: {} },
         { provide: MatDialog, useValue: {} },
         { provide: ActivatedRoute, useValue: { snapshot: { params: {} } } },
@@ -112,7 +109,7 @@ describe('ModuleCreationComponent without extractFile()', () => {
         { provide: QuizStoreService, useValue: {} },
         { provide: QuizResolverService, useValue: {} },
         { provide: ZipJSResolverService, useValue: {} },
-      ]
+      ],
     }).compileComponents()
 
     fixture = TestBed.createComponent(ModuleCreationComponent)
@@ -138,7 +135,7 @@ describe('ModuleCreationComponent without extractFile()', () => {
     expect(component.showChildrenMap[module.identifier]).toBe(false)
   })
 
-  it('should not change other modules\' showChildren properties', () => {
+  it("should not change other modules' showChildren properties", () => {
     const module1 = { identifier: 'module1' }
     const module2 = { identifier: 'module2' }
 
@@ -151,4 +148,36 @@ describe('ModuleCreationComponent without extractFile()', () => {
     expect(component.showChildrenMap[module2.identifier]).toBe(false)
   })
 
+  describe('isAssessmentResource (drives the "Show Correct Answer Popup" visibility)', () => {
+    it('is true only for an Assessment (application/json + isAssessment, not self-assessment)', () => {
+      component.isSelfAssessment = false
+      component.content = { mimeType: 'application/json', isAssessment: true } as any
+      expect(component.isAssessmentResource).toBe(true)
+    })
+
+    it('is false for a Quiz (application/json but isAssessment false)', () => {
+      component.isSelfAssessment = false
+      component.content = { mimeType: 'application/json', isAssessment: false } as any
+      expect(component.isAssessmentResource).toBe(false)
+    })
+
+    it('is false for a Self Assessment', () => {
+      component.isSelfAssessment = true
+      component.content = { mimeType: 'application/json', isAssessment: true } as any
+      expect(component.isAssessmentResource).toBe(false)
+    })
+
+    it('is false for pdf / audio / video even if isAssessment leaks truthy', () => {
+      component.isSelfAssessment = false
+      for (const mimeType of ['application/pdf', 'audio/mpeg', 'video/mp4', 'text/x-url']) {
+        component.content = { mimeType, isAssessment: true } as any
+        expect(component.isAssessmentResource).toBe(false)
+      }
+    })
+
+    it('is false when there is no content', () => {
+      component.content = undefined as any
+      expect(component.isAssessmentResource).toBe(false)
+    })
+  })
 })

--- a/project/ws/author/src/lib/routing/modules/editor/routing/modules/collection/components/collection/module-creation/module-creation.component.ts
+++ b/project/ws/author/src/lib/routing/modules/editor/routing/modules/collection/components/collection/module-creation/module-creation.component.ts
@@ -1,4 +1,17 @@
-import { Component, ChangeDetectorRef, OnInit, OnChanges, SimpleChanges, AfterViewInit, ViewChild, TemplateRef, Output, EventEmitter, Input, ElementRef } from '@angular/core'
+import {
+  Component,
+  ChangeDetectorRef,
+  OnInit,
+  OnChanges,
+  SimpleChanges,
+  AfterViewInit,
+  ViewChild,
+  TemplateRef,
+  Output,
+  EventEmitter,
+  Input,
+  ElementRef,
+} from '@angular/core'
 
 declare const zip: any
 
@@ -50,7 +63,12 @@ import { Router } from '@angular/router'
 
 import { environment } from '../../../../../../../../../../../../../.././src/environments/environment'
 
-import { ConfigurationsService, ImageCropComponent, ValueService, ResourceDownloadService } from '../../../../../../../../../../../../../.././library/ws-widget/utils/src/public-api'
+import {
+  ConfigurationsService,
+  ImageCropComponent,
+  ValueService,
+  ResourceDownloadService,
+} from '../../../../../../../../../../../../../.././library/ws-widget/utils/src/public-api'
 
 import { SuccessDialogComponent } from '../../../../../../../../.././modules/shared/components/success-dialog/success-dialog.component'
 
@@ -73,11 +91,7 @@ import { IFormMeta } from '../../../../../../../../../interface/form'
 
 import { VIDEO_MAX_SIZE } from '@ws/author/src/lib/constants/upload'
 
-import {
-  CONTENT_BASE_STATIC,
-  CONTENT_BASE_STREAM,
-  CONTENT_BASE_WEBHOST,
-} from '@ws/author/src/lib/constants/apiEndpoints'
+import { CONTENT_BASE_STATIC, CONTENT_BASE_STREAM, CONTENT_BASE_WEBHOST } from '@ws/author/src/lib/constants/apiEndpoints'
 
 import { ProfanityService } from '../../../../upload/services/profanity.service'
 
@@ -95,9 +109,7 @@ import { BreakpointObserver, Breakpoints, BreakpointState } from '@angular/cdk/l
 
 import { UserIndexConfirmComponent } from '@ws/author/src/lib/modules/shared/components/user-index-confirm/user-index-confirm.component'
 
-import {
-  ContentProgressService,
-} from '@ws-widget/collection'
+import { ContentProgressService } from '@ws-widget/collection'
 
 import moment from 'moment'
 
@@ -109,16 +121,14 @@ import { NewImageCropComponent } from '@ws-widget/utils/src/public-api'
   templateUrl: './module-creation.component.html',
   styleUrls: ['./module-creation.component.scss'],
   providers: [CollectionStoreService, CollectionResolverService, QuizResolverService],
-
 })
-
 export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit {
   @ViewChild('guideline', { static: false }) guideline!: TemplateRef<HTMLElement>
   @ViewChild('errorFile', { static: false }) errorFile!: TemplateRef<HTMLElement>
   @ViewChild('selectFile', { static: false }) selectFile!: TemplateRef<HTMLElement>
   @ViewChild('videoPlayer', { static: false }) videoPlayer!: ElementRef<HTMLVideoElement>
   @Output() data = new EventEmitter<any>()
-  @Output() sendSteps = new EventEmitter<any>();
+  @Output() sendSteps = new EventEmitter<any>()
   contents: NSContent.IContentMeta[] = []
   @Output() actions = new EventEmitter<{ action: string; type?: string }>()
   // Emits whether the course has the minimum 2 resources required to advance to
@@ -132,38 +142,37 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
   dragEle1: any
   dragEle2: any
   dragEle3: any
-  showQuizForm: boolean = false;
+  showQuizForm: boolean = false
   currentIndex: any
-  activeTabIndex: number = 0;
+  activeTabIndex: number = 0
 
-
-  videoQuestions: IVideoQuestionData[] = []; // Initialize videoQuestions as an empty array
+  videoQuestions: IVideoQuestionData[] = [] // Initialize videoQuestions as an empty array
   contentList: any[] = [
     {
       name: 'Link',
       icon: 'cbp-assets/icons/link_icon.png',
-      type: 'web'
+      type: 'web',
     },
     {
       name: 'PDF',
       icon: 'cbp-assets/icons/pdf_icon.svg',
-      type: 'upload'
+      type: 'upload',
     },
     {
       name: 'Audio',
       icon: 'cbp-assets/icons/audio_icon.svg',
-      type: 'upload'
+      type: 'upload',
     },
     {
       name: 'Video',
       icon: 'cbp-assets/icons/video_icon.svg',
-      type: 'upload'
+      type: 'upload',
     },
     {
       name: 'SCORM v1.1/1.2',
       icon: 'cbp-assets/icons/scrom_icon.svg',
-      type: 'upload'
-    }
+      type: 'upload',
+    },
   ]
 
   accessList: any[] = [
@@ -171,14 +180,14 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       name: 'Assessment',
       icon: 'cbp-assets/icons/assessment_icon.svg',
       type: 'assessment',
-      text: 'User can go to next module only when they complete the assessment'
+      text: 'User can go to next module only when they complete the assessment',
     },
     {
       name: 'Quiz',
       icon: 'cbp-assets/icons/quiz_icon.svg',
       type: 'assessment',
-      text: 'Users knowledge check. Shows correct answers at the end of quiz.'
-    }
+      text: 'Users knowledge check. Shows correct answers at the end of quiz.',
+    },
   ]
   assessmentOrQuizName: string = 'Quiz'
   isAddOrEdit: boolean = false
@@ -189,30 +198,30 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
   parentHierarchy: number[] = []
   showAddModuleForm: boolean = false
   showSettingsPage: boolean = false
-  moduleNames: any = [];
+  moduleNames: any = []
   isSaveModuleFormEnable: boolean = false
-  moduleButtonName: string = 'Create';
+  moduleButtonName: string = 'Create'
   isResourceTypeEnabled: boolean = false
   isLinkPageEnabled: boolean = false
-  isOnClickOfResourceTypeEnabled: boolean = false;
+  isOnClickOfResourceTypeEnabled: boolean = false
   resourceLinkForm: FormGroup
   resourcePdfForm: FormGroup
   moduleForm!: FormGroup
-  resourceImg: string = '';
-  isLinkEnabled: boolean = false;
+  resourceImg: string = ''
+  isLinkEnabled: boolean = false
   assessment!: boolean
-  isShowDownloadBtnEnabled: boolean = false;
+  isShowDownloadBtnEnabled: boolean = false
   openinnewtab: boolean = false
-  moduleName: string = '';
-  isNewTab: any = '';
-  isShowBtn: any = '';
-  isGating: any = '';
+  moduleName: string = ''
+  isNewTab: any = ''
+  isShowBtn: any = ''
+  isGating: any = ''
   topicDescription: string = ''
   thumbnail: string = ''
-  resourceNames: any = [];
-  resourceCount: number = 0;
-  independentResourceNames: any = [];
-  independentResourceCount: number = 0;
+  resourceNames: any = []
+  resourceCount: number = 0
+  independentResourceNames: any = []
+  independentResourceCount: number = 0
   imageTypes = IMAGE_SUPPORT_TYPES
   bucket: string = ''
   // Backed by a setter so that every reassignment of the course tree (add / save /
@@ -220,7 +229,9 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
   // "has >= 2 resources" validity to the parent stepper. Relying on a single emit
   // point left Next disabled after resources were added through other paths.
   private _courseData: any
-  get courseData(): any { return this._courseData }
+  get courseData(): any {
+    return this._courseData
+  }
   set courseData(value: any) {
     this._courseData = value
     this.validityChange.emit(this.getTotalResourceCount() >= 2)
@@ -234,14 +245,14 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
   routerSubscription: Subscription | null = null
   courseName: any
   currentParentId!: string
-  showResource: boolean = false;
+  showResource: boolean = false
   triggerQuizSave = false
   triggerUploadSave = false
   isChanged = false
   versionKey: any
   versionID: any
   isSubmitPressed = false
-  isMoveCourseToDraft: boolean = false;
+  isMoveCourseToDraft: boolean = false
   gatingEnabled!: FormControl
   hours = 0
   minutes = 0
@@ -257,7 +268,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
   resourseSelected: string = ''
   viewMode!: string
   content: any
-  canUpdate: boolean = true;
+  canUpdate: boolean = true
   isPdfOrAudioOrVedioEnabled!: boolean
   acceptType!: string | '.mp3,.mp4,.pdf,.zip,.m4v'
   addResourceModule: any = {}
@@ -281,16 +292,17 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
   mainCourseDuration: string = ''
   entryPoint: any
   uploadText!: string
-  uploadFileName: string = '';
-  uploadVideoUrl: string = '';
+  uploadFileName: string = ''
+  uploadVideoUrl: string = ''
   uploadIcon!: string
   isSelfAssessment: boolean = false
   hideModule: boolean = false
   hideResource: boolean = false
-  questionType: IQuizQuestionType['fillInTheBlanks'] |
-    IQuizQuestionType['matchTheFollowing'] |
-    IQuizQuestionType['multipleChoiceQuestionSingleCorrectAnswer'] |
-    IQuizQuestionType['multipleChoiceQuestionMultipleCorrectAnswer'] = QUIZ_QUESTION_TYPE['multipleChoiceQuestionSingleCorrectAnswer']
+  questionType:
+    | IQuizQuestionType['fillInTheBlanks']
+    | IQuizQuestionType['matchTheFollowing']
+    | IQuizQuestionType['multipleChoiceQuestionSingleCorrectAnswer']
+    | IQuizQuestionType['multipleChoiceQuestionMultipleCorrectAnswer'] = QUIZ_QUESTION_TYPE['multipleChoiceQuestionSingleCorrectAnswer']
   parentNodeId!: number
   assessmentData: any
   assessmentDuration!: any
@@ -306,7 +318,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
   mediumScreenSize!: boolean
   showContent!: boolean
   canEditJson!: boolean
-  questionsArr: any[] = [];
+  questionsArr: any[] = []
   contentLoaded!: boolean
   currentId!: string
   quizDuration: any
@@ -323,25 +335,25 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
   editItem: string = ''
   resourceDurat: any = []
   sumDuration: any
-  @Input() clickedNext: boolean = false;
+  @Input() clickedNext: boolean = false
   @Input() triggerNext = false
   triggerCourseSettingsNext = false
-  showChildrenMap: { [key: string]: boolean } = {};
+  showChildrenMap: { [key: string]: boolean } = {}
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes['triggerNext']?.currentValue === true) {
       if (this.isSettingsPage) {
         this.triggerCourseSettingsNext = true
-        setTimeout(() => { this.triggerCourseSettingsNext = false }, 50)
+        setTimeout(() => {
+          this.triggerCourseSettingsNext = false
+        }, 50)
       } else {
         // A course must contain at least 2 resources before it can move to the
         // Course Settings step. Block the stepper Next and tell the user otherwise.
         if (this.getTotalResourceCount() < 2) {
-          this.snackBar.open(
-            'Please add at least 2 resources before proceeding to Course Settings.',
-            'X',
-            { duration: NOTIFICATION_TIME * 1000 },
-          )
+          this.snackBar.open('Please add at least 2 resources before proceeding to Course Settings.', 'X', {
+            duration: NOTIFICATION_TIME * 1000,
+          })
           return
         }
         this.setSettingsPage()
@@ -368,7 +380,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
   // whole list (and its child components) on every change. Identifier for content
   // nodes, index for primitive/option lists.
   trackByIdentifier(index: number, item: any): any {
-    return (item && item.identifier) ? item.identifier : index
+    return item && item.identifier ? item.identifier : index
   }
 
   trackByIndex(index: number): number {
@@ -378,8 +390,12 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
   // Download a single resource (file as-is, or quiz -> Excel). stopPropagation so the
   // row's edit/drag handlers don't fire when the download icon is clicked.
   async downloadOneResource(resource: any, event?: Event): Promise<void> {
-    if (event) { event.stopPropagation() }
-    if (!resource || (!resource.artifactUrl && !resource.downloadUrl)) { return }
+    if (event) {
+      event.stopPropagation()
+    }
+    if (!resource || (!resource.artifactUrl && !resource.downloadUrl)) {
+      return
+    }
     this.loader.changeLoad.next(true)
     try {
       await this.resourceDownloadSvc.downloadResource(resource)
@@ -394,8 +410,12 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
 
   // Download every resource in the course as one zip named after the course.
   async downloadAllResources(event?: Event): Promise<void> {
-    if (event) { event.stopPropagation() }
-    if (!this.resourceDownloadSvc.hasDownloadableResources(this.courseData)) { return }
+    if (event) {
+      event.stopPropagation()
+    }
+    if (!this.resourceDownloadSvc.hasDownloadableResources(this.courseData)) {
+      return
+    }
     this.loader.changeLoad.next(true)
     try {
       await this.resourceDownloadSvc.downloadAllAsZip(this.courseData)
@@ -444,7 +464,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       showDownloadBtn: new FormControl(''),
       isIframeSupported: new FormControl(''),
       isgatingEnabled: new FormControl(),
-      duration: new FormControl('', [Validators.required])
+      duration: new FormControl('', [Validators.required]),
     })
 
     this.fileUploadForm = this.formBuilder.group({
@@ -468,11 +488,11 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       isIframeSupported: new FormControl(''),
       showDownloadBtn: new FormControl(''),
       isgatingEnabled: new FormControl(),
-      duration: new FormControl('', [Validators.required])
+      duration: new FormControl('', [Validators.required]),
     })
 
     this.moduleForm = new FormGroup({
-      appIcon: new FormControl('')
+      appIcon: new FormControl(''),
     })
 
     this.assessmentOrQuizForm = new FormGroup({
@@ -499,13 +519,12 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       }
     })
 
-    this.initService.updateResourceMessage.subscribe(
-      async (data: any) => {
-        if (data) {
-          await this.ngAfterViewInit()
-          this.cdr.detectChanges()
-        }
-      })
+    this.initService.updateResourceMessage.subscribe(async (data: any) => {
+      if (data) {
+        await this.ngAfterViewInit()
+        this.cdr.detectChanges()
+      }
+    })
   }
 
   ngOnInit() {
@@ -553,7 +572,6 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
     })
     if (this.activateRoute.parent && this.activateRoute.parent.parent) {
       this.routerSubscription = this.activateRoute.parent.parent.data.subscribe(data => {
-
         this.courseName = data.contents[0].content.name
         this.courseData = data.contents[0].content
 
@@ -585,14 +603,12 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         })
         contentDataMap.forEach(content => this.contentService.setOriginalMeta(content))
         const currentNode = (this.storeService.lexIdMap.get(this.currentContent) as number[])[0]
-        console.log("here noe", currentNode)
+        console.log('here noe', currentNode)
         this.currentParentId = this.currentContent
-        this.storeService.treeStructureChange.next(
-          this.storeService.flatNodeMap.get(currentNode) as IContentNode,
-        )
+        this.storeService.treeStructureChange.next(this.storeService.flatNodeMap.get(currentNode) as IContentNode)
         this.storeService.currentParentNode = currentNode
         this.storeService.currentSelectedNode = currentNode
-        console.log("currentSelectedNode", this.storeService.currentParentNode, currentNode)
+        console.log('currentSelectedNode', this.storeService.currentParentNode, currentNode)
         let newCreatedNode = 0
         const newCreatedLexid = this.editorService.newCreatedLexid
         if (newCreatedLexid) {
@@ -600,10 +616,16 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
           this.storeService.selectedNodeChange.next(newCreatedNode)
         }
 
-        if (data.contents[0] && data.contents[0].content && data.contents[0].content.children[0] &&
-          data.contents[0].content.children[0].identifier) {
+        if (
+          data.contents[0] &&
+          data.contents[0].content &&
+          data.contents[0].content.children[0] &&
+          data.contents[0].content.children[0].identifier
+        ) {
           this.subActions({
-            type: 'editContent', identifier: data.contents[0].content.identifier, nodeClicked: true
+            type: 'editContent',
+            identifier: data.contents[0].content.identifier,
+            nodeClicked: true,
           })
           this.storeService.selectedNodeChange.next(data.contents[0].content.identifier)
         }
@@ -616,11 +638,10 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         if (urlParam === 'collection') {
           this.headerService.showCreatorHeader(this.courseName)
         }
-
       })
     }
   }
-  subActions(event: { type: string; identifier: string, nodeClicked?: boolean }) {
+  subActions(event: { type: string; identifier: string; nodeClicked?: boolean }) {
     // const nodeClicked = event.nodeClicked
     this.contentService.changeActiveCont.next(event.identifier)
     switch (event.type) {
@@ -631,7 +652,11 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         if (event.nodeClicked === false) {
         }
         const content = this.contentService.getUpdatedMeta(event.identifier)
-        if (['application/pdf', 'application/x-mpegURL', 'application/vnd.ekstep.html-archive', 'audio/mpeg', 'video/mp4'].includes(content.mimeType)) {
+        if (
+          ['application/pdf', 'application/x-mpegURL', 'application/vnd.ekstep.html-archive', 'audio/mpeg', 'video/mp4'].includes(
+            content.mimeType,
+          )
+        ) {
           this.viewMode = 'upload'
           // } else if (['video/x-youtube', 'text/x-url', 'application/html'].includes(content.mimeType) && content.fileType === 'link') {
         } else if (['video/x-youtube', 'text/x-url', 'application/html'].includes(content.mimeType) && content.fileType === '') {
@@ -648,7 +673,8 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         break
     }
   }
-  action(type: string) {      // recheck
+  action(type: string) {
+    // recheck
     // tslint:disable-next-line:no-console
     switch (type) {
       case 'next':
@@ -660,7 +686,6 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         break
 
       case 'scroll':
-
         const el = document.getElementById('edit-meta')
         if (el) {
           el.scrollIntoView()
@@ -682,7 +707,6 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       //   break
 
       case 'push':
-
         if (this.getAction() === 'publish') {
           const dialogRefForPublish = this.dialog.open(ConfirmDialogComponent, {
             width: '70%',
@@ -760,17 +784,17 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
     this.videoQuestions.push({
       timestamp: { hours: 0, minutes: 0, seconds: 0 },
       timestampInSeconds: 0,
-      question: [ // Ensure 'question' is used here
+      question: [
+        // Ensure 'question' is used here
         {
           text: '',
-          options: [{ text: '', optionId: this.generateOptionId(), isCorrect: false, answerInfo: '' }]
-        }
-      ]
+          options: [{ text: '', optionId: this.generateOptionId(), isCorrect: false, answerInfo: '' }],
+        },
+      ],
     })
     this.activeTabIndex = this.videoQuestions.length - 1 // Set active tab to the newly added question
     console.log('Video Questions:', this.videoQuestions) // Debugging step
     this.cdr.detectChanges()
-
   }
   deleteQuestion(index: number) {
     const dialogRef = this.dialog.open(ConfirmDialogComponent, {
@@ -806,12 +830,12 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
   }
   setCorrectOption(i: number, j: number, k: number): void {
     this.videoQuestions[i].question[j].options.forEach((option, index) => {
-      option.isCorrect = (index === k)
+      option.isCorrect = index === k
     })
   }
   updateTimestampInSeconds(index: number): void {
     const { hours, minutes, seconds } = this.videoQuestions[index].timestamp
-    this.videoQuestions[index].timestampInSeconds = (hours * 3600) + (minutes * 60) + seconds
+    this.videoQuestions[index].timestampInSeconds = hours * 3600 + minutes * 60 + seconds
   }
 
   // Captures the true video length from the browser once metadata is available, so
@@ -827,7 +851,9 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
   // True when this question's timestamp falls past the end of the video, so the quiz
   // would never trigger. Returns false until the real duration is known.
   isTimestampBeyondVideo(question: { timestampInSeconds: number }): boolean {
-    if (this.videoActualDuration == null) { return false }
+    if (this.videoActualDuration == null) {
+      return false
+    }
     return question.timestampInSeconds > this.videoActualDuration
   }
 
@@ -840,7 +866,12 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
     return this.videoQuestions.some((q: any) => q.timestampInSeconds > this.videoActualDuration!)
   }
   addOption(questionIndex: number, subQuestionIndex: number) {
-    this.videoQuestions[questionIndex].question[subQuestionIndex].options.push({ optionId: this.generateOptionId(), text: '', isCorrect: false, answerInfo: '' })
+    this.videoQuestions[questionIndex].question[subQuestionIndex].options.push({
+      optionId: this.generateOptionId(),
+      text: '',
+      isCorrect: false,
+      answerInfo: '',
+    })
   }
 
   clearOption(questionIndex: number, subQuestionIndex: number, optionIndex: number) {
@@ -861,21 +892,20 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
     const updatedContent = this.contentService.upDatedContent || {}
     if (this.viewMode === 'assessment') {
       this.triggerQuizSave = true
-    } else
-      if (this.viewMode === 'upload') {
-        // TODO  console.log('viewmode', this.viewMode)
-        this.triggerUploadSave = true
-      }
+    } else if (this.viewMode === 'upload') {
+      // TODO  console.log('viewmode', this.viewMode)
+      this.triggerUploadSave = true
+    }
 
     if (
       (Object.keys(updatedContent).length &&
-        (Object.values(updatedContent).length && JSON.stringify(Object.values(updatedContent)[0]) !== '{}')) ||
+        Object.values(updatedContent).length &&
+        JSON.stringify(Object.values(updatedContent)[0]) !== '{}') ||
       Object.keys(this.storeService.changedHierarchy).length
     ) {
-
       this.isChanged = true
       this.loader.changeLoad.next(true)
-      if (this.contentService.getUpdatedMeta(this.currentCourseId).contentType !== "CourseUnit") {
+      if (this.contentService.getUpdatedMeta(this.currentCourseId).contentType !== 'CourseUnit') {
         this.versionID = await this.editorService.readcontentV3(this.currentCourseId).toPromise()
         this.versionKey = this.contentService.getUpdatedMeta(this.currentCourseId)
       }
@@ -883,7 +913,6 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       this.saveTriggerSub = this.triggerSaves().subscribe(
         () => {
           if (nextAction) {
-
             this.action(nextAction)
           }
           this.loader.changeLoad.next(false)
@@ -896,15 +925,12 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
           // tslint:disable-next-line:no-console
 
           // this.isSettingsPage = false
-
         },
         (error: any) => {
           if (error.status === 409) {
             this.isError = true
             const errorMap = new Map<string, NSContent.IContentMeta>()
-            Object.keys(this.contentService.originalContent).forEach(v =>
-              errorMap.set(v, this.contentService.originalContent[v]),
-            )
+            Object.keys(this.contentService.originalContent).forEach(v => errorMap.set(v, this.contentService.originalContent[v]))
             const dialog = this.dialog.open(ErrorParserComponent, {
               width: '600px',
               data: {
@@ -935,7 +961,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
             this.courseData = await data
             this.contentService.resetOriginalMetaWithHierarchy(data)
             if (this.isSettingsPage && !this.isError) {
-              this.action("push")
+              this.action('push')
               this.loader.changeLoad.next(false)
             }
             // tslint:disable-next-line: align
@@ -991,30 +1017,34 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         let competencyLevelDescription = tempUpdateContent.competencies_v1.additionalProperties
         let lang = this.courseData.lang
         if (lang == 'hi') {
-          tempUpdateContent.competencies_v1.name = competencyLevelDescription['lang-hi-name'] ? competencyLevelDescription['lang-hi-name'] : tempUpdateContent.competencies_v1.name
+          tempUpdateContent.competencies_v1.name = competencyLevelDescription['lang-hi-name']
+            ? competencyLevelDescription['lang-hi-name']
+            : tempUpdateContent.competencies_v1.name
         }
-        let competencies_obj = [{
-          competencyName: tempUpdateContent.competencies_v1.name,
-          competencyId: tempUpdateContent.competencies_v1.id.toString(),
-        }]
+        let competencies_obj = [
+          {
+            competencyName: tempUpdateContent.competencies_v1.name,
+            competencyId: tempUpdateContent.competencies_v1.id.toString(),
+          },
+        ]
         tempUpdateContent.competencies_v1 = competencies_obj
       }
 
       // this.uploadVideoUrl = tempUpdateContent.artifactUrl ? tempUpdateContent.artifactUrl : ''
-      console.log("tempUpdateContent", tempUpdateContent, this.uploadVideoUrl)
+      console.log('tempUpdateContent', tempUpdateContent, this.uploadVideoUrl)
       requestBody = {
         request: {
           content: tempUpdateContent,
-        }
+        },
       }
       // tslint:disable-next-line:no-console
 
       requestBody.request.content = this.contentService.cleanProperties(requestBody.request.content)
 
       if (requestBody.request.content.duration === 0 || requestBody.request.content.duration) {
-        requestBody.request.content.duration =
-          isNumber(requestBody.request.content.duration) ?
-            requestBody.request.content.duration.toString() : requestBody.request.content.duration
+        requestBody.request.content.duration = isNumber(requestBody.request.content.duration)
+          ? requestBody.request.content.duration.toString()
+          : requestBody.request.content.duration
       }
 
       if (requestBody.request.content.category) {
@@ -1067,9 +1097,13 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       this.contentService.currentContentID = this.currentCourseId
       //let nodesModified = {}
       // tslint:disable-next-line:no-console
-      console.log("requestBody", requestBody)
+      console.log('requestBody', requestBody)
 
-      if (tempUpdateContent.category === 'Resource' || tempUpdateContent.category === undefined || tempUpdateContent.category === 'Course') {
+      if (
+        tempUpdateContent.category === 'Resource' ||
+        tempUpdateContent.category === undefined ||
+        tempUpdateContent.category === 'Course'
+      ) {
         return this.editorService.updateNewContentV3(_.omit(requestBody, ['resourceType']), this.currentCourseId).pipe(
           tap(() => {
             this.storeService.changedHierarchy = {}
@@ -1079,7 +1113,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
               this.courseData = await data
               this.contentService.resetOriginalMetaWithHierarchy(data)
               if (this.isSettingsPage && !this.isError) {
-                this.action("push")
+                this.action('push')
                 this.loader.changeLoad.next(false)
               }
               // tslint:disable-next-line: align
@@ -1088,12 +1122,10 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
               this.contentService.resetOriginalMeta(this.contentService.upDatedContent[id], id)
             })
             this.contentService.upDatedContent = {}
-          })
+          }),
         )
       } else {
-
       }
-
     }
 
     const requestBodyV2: NSApiRequest.IContentUpdateV3 = {
@@ -1104,7 +1136,6 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         },
       },
     }
-
 
     return this.editorService.updateContentV4(requestBodyV2).pipe(
       tap(() => {
@@ -1119,12 +1150,10 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         this.contentService.upDatedContent = {}
       }),
     )
-
-
   }
   async updates() {
     // tslint:disable-next-line:no-console
-    console.log("update")
+    console.log('update')
     this.resourseSelected = ''
     const requestBodyV2: NSApiRequest.IContentUpdateV3 = {
       request: {
@@ -1144,7 +1173,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
   }
   get validationCheck(): boolean {
     const currentNodeId = this.storeService.lexIdMap.get(this.currentParentId) as number[]
-    console.log("this.courseData", this.courseData)
+    console.log('this.courseData', this.courseData)
     let returnValue = this.storeService.validationCheck(currentNodeId[0], this.courseData)
 
     // console.log('returnvalue ', returnValue)
@@ -1163,15 +1192,11 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       dialog.afterClosed().subscribe(v => {
         if (v) {
           if (typeof v === 'string') {
-            this.storeService.selectedNodeChange.next(
-              (this.storeService.lexIdMap.get(v) as number[])[0],
-            )
+            this.storeService.selectedNodeChange.next((this.storeService.lexIdMap.get(v) as number[])[0])
             this.contentService.changeActiveCont.next(v)
           } else {
             this.storeService.selectedNodeChange.next(v)
-            this.contentService.changeActiveCont.next(
-              this.storeService.uniqueIdMap.get(v) as string,
-            )
+            this.contentService.changeActiveCont.next(this.storeService.uniqueIdMap.get(v) as string)
           }
         }
         this.isError = false
@@ -1184,19 +1209,13 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
     this.isSubmitPressed = true
 
     if (this.validationCheck) {
-
       this.editorService.readcontentV3(this.contentService.parentContent).subscribe((resData: any) => {
         if (resData && Object.keys(resData).length > 0) {
-          resData.creatorContacts =
-            this.jsonVerify(resData.creatorContacts) ? JSON.parse(resData.creatorContacts) : []
-          resData.trackContacts =
-            this.jsonVerify(resData.reviewer) ? JSON.parse(resData.reviewer) : []
-          resData.gatingEnabled =
-            this.jsonVerify(resData.gatingEnabled) ? JSON.parse(resData.gatingEnabled) : []
-          resData.creatorDetails =
-            this.jsonVerify(resData.creatorDetails) ? JSON.parse(resData.creatorDetails) : []
-          resData.publisherDetails = this.jsonVerify(resData.publisherDetails) ?
-            JSON.parse(resData.publisherDetails) : []
+          resData.creatorContacts = this.jsonVerify(resData.creatorContacts) ? JSON.parse(resData.creatorContacts) : []
+          resData.trackContacts = this.jsonVerify(resData.reviewer) ? JSON.parse(resData.reviewer) : []
+          resData.gatingEnabled = this.jsonVerify(resData.gatingEnabled) ? JSON.parse(resData.gatingEnabled) : []
+          resData.creatorDetails = this.jsonVerify(resData.creatorDetails) ? JSON.parse(resData.creatorDetails) : []
+          resData.publisherDetails = this.jsonVerify(resData.publisherDetails) ? JSON.parse(resData.publisherDetails) : []
           if (resData.children.length > 0) {
             resData.children.forEach((element: any) => {
               element.creatorContacts = this.jsonVerify(element.creatorContacts) ? JSON.parse(element.creatorContacts) : []
@@ -1218,7 +1237,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
           data: this.contentService.getOriginalMeta(this.currentParentId),
         })
 
-        dialogRef.afterClosed().subscribe((d) => {
+        dialogRef.afterClosed().subscribe(d => {
           console.log(d)
           this.isVisibleReviewDialog = false
           // this.finalCall(contentAction)
@@ -1227,55 +1246,59 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
               contentAction = 'rejectContent'
               //this.finalCall(contentAction)
               let dat = {
-                "userId": this._configurationsService!.userProfile!.userId,
-                "courseId": this.courseData.identifier,
-                "role": "creator",
-                "comments": d.value.comments,
-                "currentStatus": "Draft",
-                "nextStatus": "Sent for Review",
-                "readComments": false,
-                "createdDate": moment(new Date()).toISOString(),
-                "updatedDate": moment(new Date()).toISOString(),
-                "username": this._configurationsService!.userProfile!.userName
-
+                userId: this._configurationsService!.userProfile!.userId,
+                courseId: this.courseData.identifier,
+                role: 'creator',
+                comments: d.value.comments,
+                currentStatus: 'Draft',
+                nextStatus: 'Sent for Review',
+                readComments: false,
+                createdDate: moment(new Date()).toISOString(),
+                updatedDate: moment(new Date()).toISOString(),
+                username: this._configurationsService!.userProfile!.userName,
               }
-              this.progressSvc.addComment(dat).subscribe(res => {
-                console.log(res)
-                if (res) {
-                  this.finalCall(contentAction)
-                }
-                //this.commentsList = res
-              }, (err: any) => {
-                console.log(err)
-                this.finalCall(contentAction)
-              })
-              console.log(contentAction)
-            } else {
-              console.log(contentAction)
-              if (contentAction === 'acceptConent') {
-                let dat = {
-                  "userId": this._configurationsService!.userProfile!.userId,
-                  "courseId": this.courseData.identifier,
-                  "role": "creator",
-                  "comments": d.value.comments,
-                  "currentStatus": "Draft",
-                  "nextStatus": "Sent for Review",
-                  "readComments": false,
-                  "createdDate": moment(new Date()).toISOString(),
-                  "updatedDate": moment(new Date()).toISOString(),
-                  "username": this._configurationsService!.userProfile!.userName
-
-                }
-                this.progressSvc.addComment(dat).subscribe(res => {
+              this.progressSvc.addComment(dat).subscribe(
+                res => {
                   console.log(res)
                   if (res) {
                     this.finalCall(contentAction)
                   }
                   //this.commentsList = res
-                }, (err: any) => {
+                },
+                (err: any) => {
                   console.log(err)
                   this.finalCall(contentAction)
-                })
+                },
+              )
+              console.log(contentAction)
+            } else {
+              console.log(contentAction)
+              if (contentAction === 'acceptConent') {
+                let dat = {
+                  userId: this._configurationsService!.userProfile!.userId,
+                  courseId: this.courseData.identifier,
+                  role: 'creator',
+                  comments: d.value.comments,
+                  currentStatus: 'Draft',
+                  nextStatus: 'Sent for Review',
+                  readComments: false,
+                  createdDate: moment(new Date()).toISOString(),
+                  updatedDate: moment(new Date()).toISOString(),
+                  username: this._configurationsService!.userProfile!.userName,
+                }
+                this.progressSvc.addComment(dat).subscribe(
+                  res => {
+                    console.log(res)
+                    if (res) {
+                      this.finalCall(contentAction)
+                    }
+                    //this.commentsList = res
+                  },
+                  (err: any) => {
+                    console.log(err)
+                    this.finalCall(contentAction)
+                  },
+                )
               }
               //this.finalCall(contentAction)
             }
@@ -1284,14 +1307,11 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       }
       if (contentAction === 'publishResources') {
         // tslint:disable-next-line:no-console
-        console.log("here", this.getAction())
+        console.log('here', this.getAction())
 
         this.finalCall(contentAction)
       }
     }
-
-
-
   }
   async finalCall(contentActionTaken: any) {
     console.log(contentActionTaken, 'tok')
@@ -1302,7 +1322,6 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
     const originalData = this.contentService.getOriginalMeta(this.contentService.parentContent)
     if (contentActionTaken === 'acceptConent' || contentActionTaken === 'publishResources') {
       if (originalData && originalData.children && originalData.children.length > 0) {
-
         for (const element of originalData.children) {
           if (element.contentType === 'CourseUnit' || element.contentType === 'Collection') {
             if (element.children.length > 0) {
@@ -1326,7 +1345,6 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
               versionKey: element.versionKey,
             }
             moduleListToReview.push(tempParentData)
-
           } else {
             const tempData = {
               name: element.name,
@@ -1346,13 +1364,11 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
           //this.contentPublish(originalData, resourceListToReview)
           // this.contentPublish(resourceListToReview)
         } else if (resourceListToReview.length > 0) {
-
           this.loader.changeLoad.next(true)
           for await (const element of resourceListToReview) {
-
             if ((element.status === 'Live' || element.status === 'Review') && updatedMeta.status === 'Draft') {
               flag += 1
-            } else if ((element.status === 'Live') && updatedMeta.status === 'Review') {
+            } else if (element.status === 'Live' && updatedMeta.status === 'Review') {
               flag += 1
             } else {
               const requestPayload = {
@@ -1364,17 +1380,19 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
                 },
               }
 
-              const reviewRes =
-                await this.editorService.sendToReview(element.identifier, updatedMeta.status).toPromise().catch(async _error => {
-                  console.log("_error.error.params", _error.error, element)
+              const reviewRes = await this.editorService
+                .sendToReview(element.identifier, updatedMeta.status)
+                .toPromise()
+                .catch(async _error => {
+                  console.log('_error.error.params', _error.error, element)
                   if (_error.error.params.status === 'failed') {
-                    let error = [{
-                      "id": element.identifier,
-                      "name": element.name,
-                      "message": [
-                        "File is not uploaded correctly"
-                      ]
-                    }]
+                    let error = [
+                      {
+                        id: element.identifier,
+                        name: element.name,
+                        message: ['File is not uploaded correctly'],
+                      },
+                    ]
                     const dialog = this.dialog.open(ErrorParserComponent, {
                       width: '80vw',
                       height: '90vh',
@@ -1382,13 +1400,15 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
                         processErrorData: error,
                       },
                     })
-                    console.log("dialog", dialog, error)
+                    console.log('dialog', dialog, error)
                   }
                 })
 
               if (reviewRes && reviewRes.params && reviewRes.params.status === 'successful') {
-                const updateContentRes =
-                  await this.editorService.updateContentWithFewFields(requestPayload, element.identifier).toPromise().catch(_error => { })
+                const updateContentRes = await this.editorService
+                  .updateContentWithFewFields(requestPayload, element.identifier)
+                  .toPromise()
+                  .catch(_error => {})
                 if (updateContentRes && updateContentRes.params && updateContentRes.params.status === 'successful') {
                   flag += 1
                 } else {
@@ -1430,12 +1450,12 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       }
     } else {
       // tslint:disable-next-line:no-console
-      console.log("yes here")
+      console.log('yes here')
       // this.changeStatusToDraft('Content Rejected')
     }
   }
   finalSaveAndRedirect(updatedMeta: any) {
-    const saveCall = (of({} as any)).pipe(
+    const saveCall = of({} as any).pipe(
       mergeMap(() =>
         this.editorService
           // .forwardBackward(
@@ -1458,8 +1478,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
               //   }),
               // ),
               return of({} as any)
-            }
-            ),
+            }),
           ),
       ),
     )
@@ -1474,8 +1493,10 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
             },
           },
         }
-        const updateConentRes =
-          await this.editorService.updateContentWithFewFields(requestPayload, updatedMeta.identifier).toPromise().catch(_error => { })
+        const updateConentRes = await this.editorService
+          .updateContentWithFewFields(requestPayload, updatedMeta.identifier)
+          .toPromise()
+          .catch(_error => {})
         if (updateConentRes && updateConentRes.params && updateConentRes.params.status === 'successful') {
           this.loader.changeLoad.next(false)
           this.snackBar.openFromComponent(NotificationComponent, {
@@ -1493,7 +1514,14 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
             this.dialog.open(SuccessDialogComponent, {
               width: '450px',
               height: '300x',
-              data: { 'message': 'Course Sent For Review', 'icon': 'check_circle', 'color': 'rgb(44, 185, 58)', 'backgroundColor': '#FFFFFF', 'padding': '6px 11px 10px 6px !important', 'id': this.contentService.parentContent },
+              data: {
+                message: 'Course Sent For Review',
+                icon: 'check_circle',
+                color: 'rgb(44, 185, 58)',
+                backgroundColor: '#FFFFFF',
+                padding: '6px 11px 10px 6px !important',
+                id: this.contentService.parentContent,
+              },
             })
             // this.router.navigate(['author', 'cbp'])
           }
@@ -1510,9 +1538,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       (error: any) => {
         if (error.status === 409) {
           const errorMap = new Map<string, NSContent.IContentMeta>()
-          Object.keys(this.contentService.originalContent).forEach(v =>
-            errorMap.set(v, this.contentService.originalContent[v]),
-          )
+          Object.keys(this.contentService.originalContent).forEach(v => errorMap.set(v, this.contentService.originalContent[v]))
           this.isError = true
           const dialog = this.dialog.open(ErrorParserComponent, {
             width: '80vw',
@@ -1525,15 +1551,11 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
           dialog.afterClosed().subscribe(v => {
             if (v) {
               if (typeof v === 'string') {
-                this.storeService.selectedNodeChange.next(
-                  (this.storeService.lexIdMap.get(v) as number[])[0],
-                )
+                this.storeService.selectedNodeChange.next((this.storeService.lexIdMap.get(v) as number[])[0])
                 this.contentService.changeActiveCont.next(v)
               } else {
                 this.storeService.selectedNodeChange.next(v)
-                this.contentService.changeActiveCont.next(
-                  this.storeService.uniqueIdMap.get(v) as string,
-                )
+                this.contentService.changeActiveCont.next(this.storeService.uniqueIdMap.get(v) as string)
               }
             }
             this.isError = false
@@ -1554,8 +1576,8 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
     const emailReqPayload = {
       contentState: actionType,
       contentLink: `${environment.cbpPortal}author/editor/${originalData.identifier}/collection`,
-      contentName: (this._configurationsService.userProfile) ? this._configurationsService.userProfile.userName : '',
-      sender: (this._configurationsService.userProfile) ? this._configurationsService.userProfile.email : '',
+      contentName: this._configurationsService.userProfile ? this._configurationsService.userProfile.userName : '',
+      sender: this._configurationsService.userProfile ? this._configurationsService.userProfile.email : '',
       recipientEmails: <any>[],
     }
     switch (actionType) {
@@ -1608,7 +1630,10 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         break
     }
     if (emailReqPayload.recipientEmails && emailReqPayload.recipientEmails.length > 0) {
-      await this.editorService.sendEmailNotificationAPI(emailReqPayload).toPromise().catch(_error => { })
+      await this.editorService
+        .sendEmailNotificationAPI(emailReqPayload)
+        .toPromise()
+        .catch(_error => {})
     }
   }
   getMessage(type: 'success' | 'failure') {
@@ -1697,10 +1722,15 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       for await (const element of resourceListToReview) {
         this.loader.changeLoad.next(true)
         updateContentReq.request.content.versionKey = element.versionKey
-        const updateContentRes =
-          await this.editorService.updateContentForReviwer(updateContentReq, element.identifier).toPromise().catch(_error => { })
+        const updateContentRes = await this.editorService
+          .updateContentForReviwer(updateContentReq, element.identifier)
+          .toPromise()
+          .catch(_error => {})
         if (updateContentRes && updateContentRes.params && updateContentRes.params.status === 'successful') {
-          const rejectRes: any = await this.editorService.rejectContentApi(requestBody, element.identifier).toPromise().catch(_error => { })
+          const rejectRes: any = await this.editorService
+            .rejectContentApi(requestBody, element.identifier)
+            .toPromise()
+            .catch(_error => {})
           if (rejectRes && rejectRes.params && rejectRes.params.status === 'successful') {
             flag += 1
           } else {
@@ -1720,13 +1750,20 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
             },
           },
         }
-        const updateHierarchyRes = await this.editorService.updateHierarchyForReviwer(tempRequset).toPromise().catch(_error => { })
+        const updateHierarchyRes = await this.editorService
+          .updateHierarchyForReviwer(tempRequset)
+          .toPromise()
+          .catch(_error => {})
         if (updateHierarchyRes && updateHierarchyRes.params && updateHierarchyRes.params.status === 'successful') {
-          const parentMetaRes =
-            await this.editorService.updateContentForReviwer(updateContentReq, originalData.identifier).toPromise().catch(_error => { })
+          const parentMetaRes = await this.editorService
+            .updateContentForReviwer(updateContentReq, originalData.identifier)
+            .toPromise()
+            .catch(_error => {})
           if (parentMetaRes && parentMetaRes.params && parentMetaRes.params.status === 'successful') {
-            const rejectParentRes: any =
-              await this.editorService.rejectContentApi(requestBody, originalData.identifier).toPromise().catch(_error => { })
+            const rejectParentRes: any = await this.editorService
+              .rejectContentApi(requestBody, originalData.identifier)
+              .toPromise()
+              .catch(_error => {})
             if (rejectParentRes && rejectParentRes.params && rejectParentRes.params.status === 'successful') {
               this.loader.changeLoad.next(false)
               this.snackBar.openFromComponent(NotificationComponent, {
@@ -1743,7 +1780,14 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
               this.dialog.open(SuccessDialogComponent, {
                 width: '450px',
                 height: '300x',
-                data: { 'message': 'Course sent back to Creator’s Draft', 'icon': 'cached', 'color': 'white', 'backgroundColor': '#407BFF', 'padding': '5px 9px 8px 6px !important', 'id': this.contentService.parentContent },
+                data: {
+                  message: 'Course sent back to Creator’s Draft',
+                  icon: 'cached',
+                  color: 'white',
+                  backgroundColor: '#407BFF',
+                  padding: '5px 9px 8px 6px !important',
+                  id: this.contentService.parentContent,
+                },
               })
               if (!this.isMoveCourseToDraft) {
                 this.router.navigate(['author', 'cbp'])
@@ -1801,38 +1845,47 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
           },
         },
       }
-      const updateRes: any =
-        await this.editorService.updateContentForReviwer(updateRequestBody, originalData.identifier).toPromise().catch(_error => { })
+      const updateRes: any = await this.editorService
+        .updateContentForReviwer(updateRequestBody, originalData.identifier)
+        .toPromise()
+        .catch(_error => {})
       if (updateRes && updateRes.params && updateRes.params.status === 'successful') {
-        this.editorService.rejectContentApi(requestBody, originalData.identifier).subscribe((parentData: any) => {
-          if (parentData && parentData.params && parentData.params.status === 'successful') {
-            this.loader.changeLoad.next(false)
-            this.snackBar.openFromComponent(NotificationComponent, {
-              data: {
-                type: Notify.SAVE_SUCCESS,
-              },
-              duration: NOTIFICATION_TIME * 1000,
-            })
-            this.dialog.open(SuccessDialogComponent, {
-              width: '450px',
-              height: '300x',
-              data: { 'message': 'Course sent back to Creator’s Draft', 'icon': 'cached', 'color': 'white', 'backgroundColor': '#407BFF', 'padding': '5px 9px 8px 6px !important', 'id': this.contentService.parentContent },
-            })
-            if (!this.isMoveCourseToDraft) {
-              this.router.navigate(['author', 'cbp'])
+        this.editorService.rejectContentApi(requestBody, originalData.identifier).subscribe(
+          (parentData: any) => {
+            if (parentData && parentData.params && parentData.params.status === 'successful') {
+              this.loader.changeLoad.next(false)
+              this.snackBar.openFromComponent(NotificationComponent, {
+                data: {
+                  type: Notify.SAVE_SUCCESS,
+                },
+                duration: NOTIFICATION_TIME * 1000,
+              })
+              this.dialog.open(SuccessDialogComponent, {
+                width: '450px',
+                height: '300x',
+                data: {
+                  message: 'Course sent back to Creator’s Draft',
+                  icon: 'cached',
+                  color: 'white',
+                  backgroundColor: '#407BFF',
+                  padding: '5px 9px 8px 6px !important',
+                  id: this.contentService.parentContent,
+                },
+              })
+              if (!this.isMoveCourseToDraft) {
+                this.router.navigate(['author', 'cbp'])
+              }
+              this.isMoveCourseToDraft = false
+            } else {
+              this.loader.changeLoad.next(false)
+              this.snackBar.openFromComponent(NotificationComponent, {
+                data: {
+                  type: Notify.SAVE_FAIL,
+                },
+                duration: NOTIFICATION_TIME * 1000,
+              })
             }
-            this.isMoveCourseToDraft = false
-          } else {
-
-            this.loader.changeLoad.next(false)
-            this.snackBar.openFromComponent(NotificationComponent, {
-              data: {
-                type: Notify.SAVE_FAIL,
-              },
-              duration: NOTIFICATION_TIME * 1000,
-            })
-          }
-        },
+          },
           // tslint:disable-next-line: align
           _error => {
             this.loader.changeLoad.next(false)
@@ -1842,7 +1895,8 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
               },
               duration: NOTIFICATION_TIME * 1000,
             })
-          })
+          },
+        )
       } else {
         this.loader.changeLoad.next(false)
         this.snackBar.openFromComponent(NotificationComponent, {
@@ -1869,10 +1923,13 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         if (element.status === 'Live' && element.parentStatus === 'Review') {
           flag += 1
         } else if (element.reviewerStatus === 'Reviewed' && element.status === 'Review') {
-          const publishRes = await this.editorService.publishContent(element.identifier).toPromise().catch(_error => {
-            this.dialog.closeAll()
-            this.snackBar.open(_error.statusText, undefined, { duration: 1000 })
-          })
+          const publishRes = await this.editorService
+            .publishContent(element.identifier)
+            .toPromise()
+            .catch(_error => {
+              this.dialog.closeAll()
+              this.snackBar.open(_error.statusText, undefined, { duration: 1000 })
+            })
           if (publishRes && publishRes.params && publishRes.params.status === 'successful') {
             flag += 1
           } else {
@@ -1921,10 +1978,13 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         })
         //}
         this.loader.changeLoad.next(false)
-
       } else {
         this.loader.changeLoad.next(false)
-        this.snackBar.open('The status of the resources present in the course is not correct, please retire the course and start over again', undefined, { duration: 3000 })
+        this.snackBar.open(
+          'The status of the resources present in the course is not correct, please retire the course and start over again',
+          undefined,
+          { duration: 3000 },
+        )
         // this.snackBar.openFromComponent(NotificationComponent, {
         //   data: {
         //     type: Notify.SAVE_FAIL,
@@ -1951,8 +2011,10 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         if (element.status === 'Live' && element.parentStatus === 'Review') {
           flag += 1
         } else if (element.reviewerStatus === 'InReview' && element.status === 'Review') {
-          const updateRes =
-            await this.editorService.updateContentForReviwer(requestPayload, element.identifier).toPromise().catch(_error => { })
+          const updateRes = await this.editorService
+            .updateContentForReviwer(requestPayload, element.identifier)
+            .toPromise()
+            .catch(_error => {})
           if (updateRes && updateRes.params && updateRes.params.status === 'successful') {
             flag += 1
           } else {
@@ -1972,8 +2034,10 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         // }
         // const updateHierarchyRes = await this.editorService.updateHierarchyForReviwer(tempRequset).toPromise().catch(_error => { })
         // if (updateHierarchyRes && updateHierarchyRes.params && updateHierarchyRes.params.status === 'successful') {
-        const parentMetaRes =
-          await this.editorService.updateContentForReviwer(requestPayload, metaData.identifier).toPromise().catch(_error => { })
+        const parentMetaRes = await this.editorService
+          .updateContentForReviwer(requestPayload, metaData.identifier)
+          .toPromise()
+          .catch(_error => {})
         if (parentMetaRes && parentMetaRes.params && parentMetaRes.params.status === 'successful') {
           this.loader.changeLoad.next(false)
           this.snackBar.openFromComponent(NotificationComponent, {
@@ -1986,7 +2050,14 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
           this.dialog.open(SuccessDialogComponent, {
             width: '550px',
             height: '300x',
-            data: { 'message': 'The course has been sent to the Aastrika publisher. Please contact the Aastrika team for course publication.', 'icon': 'check_circle', 'color': 'rgb(44, 185, 58)', 'backgroundColor': '#FFFFFF', 'padding': '6px 11px 10px 6px !important', 'id': this.contentService.parentContent },
+            data: {
+              message: 'The course has been sent to the Aastrika publisher. Please contact the Aastrika team for course publication.',
+              icon: 'check_circle',
+              color: 'rgb(44, 185, 58)',
+              backgroundColor: '#FFFFFF',
+              padding: '6px 11px 10px 6px !important',
+              id: this.contentService.parentContent,
+            },
           })
           // this.router.navigate(['author', 'cbp'])
           // } else {
@@ -2045,86 +2116,89 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
     }
   }
   ngAfterViewInit() {
-    this.editorService.readcontentV3(this.contentService.parentContent).subscribe((data: any) => {
-      this.courseData = data
-      this.isSaveModuleFormEnable = true
-      if (this.courseData && this.courseData.children && this.courseData.children.length >= 2) {
-        this.showSettingsPage = true
-      }
+    this.editorService.readcontentV3(this.contentService.parentContent).subscribe(
+      (data: any) => {
+        this.courseData = data
+        this.isSaveModuleFormEnable = true
+        if (this.courseData && this.courseData.children && this.courseData.children.length >= 2) {
+          this.showSettingsPage = true
+        }
 
-      this.moduleName = data.name
-      this.topicDescription = data.description
-      this.thumbnail = data.thumbnail
+        this.moduleName = data.name
+        this.topicDescription = data.description
+        this.thumbnail = data.thumbnail
 
-      // if (data.duration) {
-      //   const minutes = data.duration > 59 ? Math.floor(data.duration / 60) : 0
-      //   const second = data.duration % 60
-      //   const hour = minutes ? (minutes > 59 ? Math.floor(minutes / 60) : 0) : 0
-      //   const minute = minutes ? minutes % 60 : 0
-      //   const seconds = second || 0
-      //   this.mainCourseDuration = hour + ':' + minute + ':' + seconds
-      // }
-      if (data.children && data.children.length > 0) {
-        this.loader.changeLoad.next(true)
-        // Wrap in try/finally so an exception in the duration math (reduce /
-        // setCourseDuration) can never leave the global loader stuck on `true`,
-        // which previously showed an endless full-screen spinner (e.g. when
-        // navigating back from the course settings page).
-        try {
-          data.children.forEach((element: any) => {
-            if (element.contentType !== 'CourseUnit' && element.duration) {
-              this.resourceDurat.push(parseInt(element.duration))
-            }
-            if (element.children && element.children.length > 0) {
-              element.children.forEach((ele: any) => {
-                if (ele.duration) {
-                  this.resourceDurat.push(parseInt(ele.duration))
-                }
-              })
-            }
-          })
-          // tslint:disable-next-line:no-console
-          console.log(this.resourceDurat)
-          if (this.resourceDurat.length > 0) {
-            this.sumDuration = this.resourceDurat.reduce((a: any, b: any) => a + b)
+        // if (data.duration) {
+        //   const minutes = data.duration > 59 ? Math.floor(data.duration / 60) : 0
+        //   const second = data.duration % 60
+        //   const hour = minutes ? (minutes > 59 ? Math.floor(minutes / 60) : 0) : 0
+        //   const minute = minutes ? minutes % 60 : 0
+        //   const seconds = second || 0
+        //   this.mainCourseDuration = hour + ':' + minute + ':' + seconds
+        // }
+        if (data.children && data.children.length > 0) {
+          this.loader.changeLoad.next(true)
+          // Wrap in try/finally so an exception in the duration math (reduce /
+          // setCourseDuration) can never leave the global loader stuck on `true`,
+          // which previously showed an endless full-screen spinner (e.g. when
+          // navigating back from the course settings page).
+          try {
+            data.children.forEach((element: any) => {
+              if (element.contentType !== 'CourseUnit' && element.duration) {
+                this.resourceDurat.push(parseInt(element.duration))
+              }
+              if (element.children && element.children.length > 0) {
+                element.children.forEach((ele: any) => {
+                  if (ele.duration) {
+                    this.resourceDurat.push(parseInt(ele.duration))
+                  }
+                })
+              }
+            })
             // tslint:disable-next-line:no-console
-            console.log(this.sumDuration.toString(), this.courseData.duration)
-            if (this.sumDuration.toString() !== this.courseData.duration) {
-              let requestBody: any
-              requestBody = {
-                request: {
-                  content: {
-                    duration: isNumber(this.sumDuration) ?
-                      this.sumDuration.toString() : this.sumDuration,
-                    versionKey: data.versionKey
+            console.log(this.resourceDurat)
+            if (this.resourceDurat.length > 0) {
+              this.sumDuration = this.resourceDurat.reduce((a: any, b: any) => a + b)
+              // tslint:disable-next-line:no-console
+              console.log(this.sumDuration.toString(), this.courseData.duration)
+              if (this.sumDuration.toString() !== this.courseData.duration) {
+                let requestBody: any
+                requestBody = {
+                  request: {
+                    content: {
+                      duration: isNumber(this.sumDuration) ? this.sumDuration.toString() : this.sumDuration,
+                      versionKey: data.versionKey,
+                    },
                   },
                 }
+                this.editorService
+                  .updateNewContentV3(_.omit(requestBody, ['resourceType']), this.courseData.identifier)
+                  .subscribe((response: any) => {
+                    // tslint:disable-next-line:no-console
+                    console.log(response)
+                  })
               }
-              this.editorService.updateNewContentV3(_.omit(requestBody, ['resourceType']), this.courseData.identifier).subscribe((response: any) => {
-                // tslint:disable-next-line:no-console
-                console.log(response)
-              })
+              this.setCourseDuration(this.sumDuration)
             }
-            this.setCourseDuration(this.sumDuration)
+          } finally {
+            this.loader.changeLoad.next(false)
           }
-        } finally {
-          this.loader.changeLoad.next(false)
         }
-      }
-      //this.isResourceTypeEnabled = true
-      // tslint:disable-next-line:no-console
-      console.log(this.isSaveModuleFormEnable)
-      //this.contentService.resetOriginalMetaWithHierarchy(data)
-      this.cdr.detectChanges()
-    }, (error: any) => {
-      // Never leave the global loader spinning if the content read fails.
-      // tslint:disable-next-line:no-console
-      console.log('module-creation ngAfterViewInit read failed', error)
-      this.loader.changeLoad.next(false)
-    })
+        //this.isResourceTypeEnabled = true
+        // tslint:disable-next-line:no-console
+        console.log(this.isSaveModuleFormEnable)
+        //this.contentService.resetOriginalMetaWithHierarchy(data)
+        this.cdr.detectChanges()
+      },
+      (error: any) => {
+        // Never leave the global loader spinning if the content read fails.
+        // tslint:disable-next-line:no-console
+        console.log('module-creation ngAfterViewInit read failed', error)
+        this.loader.changeLoad.next(false)
+      },
+    )
   }
   setSettingsPage() {
-
     // this.editorService.readcontentV3(this.contentService.parentContent).subscribe(async (data: any) => {
     //   if (data) {
     //     this.courseData = await data
@@ -2140,12 +2214,12 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       sessionStorage.setItem('isSettingsPage', '1')
       this.isSettingsPage = true
       this.editItem = ''
-      console.log("this.settingsPage", this.isSettingsPage)
+      console.log('this.settingsPage', this.isSettingsPage)
       if (this.isSelfAssessment) {
         const steps = [
           { label: '1. Self Assessment Details', key: 'AssessmentDetails', activeStep: false, completed: true },
           { label: '2. Self Assessment Builder', key: 'AssessmentBuilder', activeStep: true, completed: false },
-          { label: '3. Self Assessment Settings', key: 'AssessmentSettings', activeStep: false, completed: false }
+          { label: '3. Self Assessment Settings', key: 'AssessmentSettings', activeStep: false, completed: false },
         ]
         console.log(steps)
         this.sendSteps.emit('AssessmentSettings')
@@ -2154,23 +2228,22 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
           { label: '1. Introduction', key: 'Introduction', activeStep: false, completed: true },
           { label: '2. Course Details', key: 'CourseDetails', activeStep: true, completed: false },
           { label: '3. Course Builder', key: 'CourseBuilder', activeStep: false, completed: false },
-          { label: '4. Course Settings', key: 'CourseSettings', activeStep: false, completed: false }
+          { label: '4. Course Settings', key: 'CourseSettings', activeStep: false, completed: false },
         ]
         console.log(steps)
         this.sendSteps.emit('CourseSettings')
       }
     }, 1000)
     // tslint:disable-next-line:no-console
-
   }
   moduleCreate(name: string, input1: string, input2: string) {
     // tslint:disable-next-line:no-console
     console.log(input1, input2)
     let obj: any = {}
     if (this.moduleButtonName == 'Create') {
-      obj["type"] = 'collection'
-      obj["name"] = input1
-      obj["description"] = input2
+      obj['type'] = 'collection'
+      obj['name'] = input1
+      obj['description'] = input2
       this.addResourceModule = obj
       this.moduleName = name
       this.isSaveModuleFormEnable = true
@@ -2210,13 +2283,11 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       this.mainCourseDuration = this.courseHours + 'h ' + this.courseMinutes + 'm ' + this.courseSeconds + 's '
     } else {
       this.mainCourseDuration = '0h ' + '0m ' + '0s '
-
     }
-
   }
   async resourceLinkSave() {
     // tslint:disable-next-line:no-console
-    console.log(" this.resourceLinkForm", this.resourceLinkForm)
+    console.log(' this.resourceLinkForm', this.resourceLinkForm)
     if (this.resourceLinkForm.status == 'INVALID' && !this.isAssessmentOrQuizEnabled) {
       this.snackBar.openFromComponent(NotificationComponent, {
         data: {
@@ -2224,8 +2295,10 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         },
         duration: NOTIFICATION_TIME * 1000,
       })
-    } else if (this.resourceLinkForm.controls.instructions.status == 'INVALID' ||
-      this.resourceLinkForm.controls.appIcon.status == 'INVALID') {
+    } else if (
+      this.resourceLinkForm.controls.instructions.status == 'INVALID' ||
+      this.resourceLinkForm.controls.appIcon.status == 'INVALID'
+    ) {
       this.snackBar.openFromComponent(NotificationComponent, {
         data: {
           type: Notify.REQUIRED_FIELD,
@@ -2244,11 +2317,11 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       } else {
         //this.versionKey = this.contentService.getUpdatedMeta(this.currentCourseId)
         let iframeSupported
-        if (this.resourceLinkForm.value.isIframeSupported)
-          iframeSupported = 'Yes'
-        else
-          iframeSupported = 'No'
-        var res = this.resourceLinkForm.value.artifactUrl.match(/(http(s)?:\/\/.)(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g)
+        if (this.resourceLinkForm.value.isIframeSupported) iframeSupported = 'Yes'
+        else iframeSupported = 'No'
+        var res = this.resourceLinkForm.value.artifactUrl.match(
+          /(http(s)?:\/\/.)(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g,
+        )
         this.versionKey = this.contentService.getUpdatedMeta(this.currentCourseId)
         if (res !== null) {
           if (this.resourceLinkForm.value.name.trim() === '') {
@@ -2269,8 +2342,8 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
               duration: this.resourceLinkForm.value.duration,
               versionKey: this.updatedVersionKey,
             }
-            // Add isCorrectAnswerPopUp for assessments
-            if (this.content && this.content.isAssessment && !this.isSelfAssessment) {
+            // Add isCorrectAnswerPopUp for assessments only
+            if (this.isAssessmentResource) {
               rBody['isCorrectAnswerPopUp'] = this.content.isCorrectAnswerPopUp !== undefined ? this.content.isCorrectAnswerPopUp : true
             }
             await this.contentService.setUpdatedMeta(rBody, this.currentContent)
@@ -2302,8 +2375,8 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
               //gatingEnabled: this.resourceLinkForm.value.isgatingEnabled,
               versionKey: this.versionKey.versionKey,
             }
-            // Add isCorrectAnswerPopUp for assessments
-            if (this.content && this.content.isAssessment && !this.isSelfAssessment) {
+            // Add isCorrectAnswerPopUp for assessments only
+            if (this.isAssessmentResource) {
               rBody['isCorrectAnswerPopUp'] = this.content.isCorrectAnswerPopUp !== undefined ? this.content.isCorrectAnswerPopUp : true
             }
             await this.contentService.setUpdatedMeta(rBody, this.currentContent)
@@ -2313,15 +2386,14 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         }
       }
     }
-
   }
   async deleteUploadedFile() {
     const dialogRef = this.dialog.open(ConfirmDialogComponent, {
       width: '350px',
-      data: 'delete'
+      data: 'delete',
     })
     dialogRef.afterClosed().subscribe(async confirm => {
-      console.log("confirm", confirm)
+      console.log('confirm', confirm)
       if (confirm) {
         this.contentService.removeListOfFilesAndUpdatedIPR(this.currentContent)
         this.uploadFileName = ''
@@ -2341,75 +2413,72 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         meta['artifactUrl'] = null
         meta['downloadUrl'] = null
         if (this.content.mimeType === 'video/mp4' || this.content.mimeType === 'audio/mpeg') {
-          meta['duration'] = "0"
+          meta['duration'] = '0'
           meta['videoQuestions'] = []
         }
         let requestBody = {
           request: {
-            content: meta
-          }
+            content: meta,
+          },
         }
         this.contentService.setUpdatedMeta(meta, this.currentContent)
         this.loader.changeLoad.next(true)
-        await this.editorService.updateNewContentV3(requestBody, this.currentContent).subscribe(
-          async (info: any) => {
-            // tslint:disable-next-line:no-console
-            console.log('info', info, this.contentService.parentContent)
-            if (info) {
-              await this.editorService.readcontentV3(this.contentService.parentContent).subscribe(async (data: any) => {
-                this.courseData = data
-                // tslint:disable-next-line:no-console
-                console.log("this.courseData", this.courseData)
-                if (info) {
-                  const hierarchyData = this.storeService.getNewTreeHierarchy(this.courseData)
+        await this.editorService.updateNewContentV3(requestBody, this.currentContent).subscribe(async (info: any) => {
+          // tslint:disable-next-line:no-console
+          console.log('info', info, this.contentService.parentContent)
+          if (info) {
+            await this.editorService.readcontentV3(this.contentService.parentContent).subscribe(async (data: any) => {
+              this.courseData = data
+              // tslint:disable-next-line:no-console
+              console.log('this.courseData', this.courseData)
+              if (info) {
+                const hierarchyData = this.storeService.getNewTreeHierarchy(this.courseData)
 
-                  const requestBodyV2: NSApiRequest.IContentUpdateV3 = {
-                    request: {
-                      data: {
-                        nodesModified: this.contentService.getNodeModifyData(),
-                        hierarchy: hierarchyData,
-                      },
+                const requestBodyV2: NSApiRequest.IContentUpdateV3 = {
+                  request: {
+                    data: {
+                      nodesModified: this.contentService.getNodeModifyData(),
+                      hierarchy: hierarchyData,
                     },
-                  }
-                  this.loader.changeLoad.next(true)
-                  await this.editorService.updateContentV4(requestBodyV2).subscribe(() => {
-                    this.editorService.readcontentV3(this.contentService.parentContent).subscribe((data: any) => {
-                      this.courseData = data
-
-                      if (this.courseData && this.courseData.children.length >= 2) {
-                        this.showSettingsPage = true
-                      } else {
-                        this.showSettingsPage = false
-                      }
-                      this.getChildrenCount()
-
-                      this.loader.changeLoad.next(false)
-                      this.snackBar.openFromComponent(NotificationComponent, {
-                        data: {
-                          type: Notify.UPLOAD_FILE_REMOVED,
-                        },
-                        duration: NOTIFICATION_TIME * 1000,
-                      })
-                      this.contentService.resetOriginalMetaWithHierarchy(data)
-                      if (this.content.mimeType === 'video/mp4' || this.content.mimeType === 'audio/mpeg') {
-                        this.updateCouseDuration(data)
-                        this.setDuration(0)
-                      }
-                    })
-                  })
+                  },
                 }
-              })
-            }
-          })
+                this.loader.changeLoad.next(true)
+                await this.editorService.updateContentV4(requestBodyV2).subscribe(() => {
+                  this.editorService.readcontentV3(this.contentService.parentContent).subscribe((data: any) => {
+                    this.courseData = data
 
+                    if (this.courseData && this.courseData.children.length >= 2) {
+                      this.showSettingsPage = true
+                    } else {
+                      this.showSettingsPage = false
+                    }
+                    this.getChildrenCount()
+
+                    this.loader.changeLoad.next(false)
+                    this.snackBar.openFromComponent(NotificationComponent, {
+                      data: {
+                        type: Notify.UPLOAD_FILE_REMOVED,
+                      },
+                      duration: NOTIFICATION_TIME * 1000,
+                    })
+                    this.contentService.resetOriginalMetaWithHierarchy(data)
+                    if (this.content.mimeType === 'video/mp4' || this.content.mimeType === 'audio/mpeg') {
+                      this.updateCouseDuration(data)
+                      this.setDuration(0)
+                    }
+                  })
+                })
+              }
+            })
+          }
+        })
       }
     })
-
   }
 
   updateCouseDuration(data: any) {
     let resourceDurat: any = []
-    let sumDuration: any = "0"
+    let sumDuration: any = '0'
     if (data.children.length > 0) {
       data.children.forEach((element: any) => {
         if (element.duration) {
@@ -2428,7 +2497,6 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       if (resourceDurat.length > 0) {
         sumDuration = resourceDurat.reduce((a: any, b: any) => a + b)
       }
-
     }
     let requestBody: any
     // tslint:disable-next-line:no-console
@@ -2437,18 +2505,18 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       requestBody = {
         request: {
           content: {
-            duration: isNumber(sumDuration) ?
-              sumDuration.toString() : sumDuration,
-            versionKey: data.versionKey
+            duration: isNumber(sumDuration) ? sumDuration.toString() : sumDuration,
+            versionKey: data.versionKey,
           },
-        }
+        },
       }
-      this.editorService.updateNewContentV3(_.omit(requestBody, ['resourceType']), this.contentService.parentContent).subscribe((response: any) => {
-        // tslint:disable-next-line:no-console
-        console.log('duration', response.duration)
-        this.setCourseDuration(isNumber(sumDuration) ?
-          sumDuration.toString() : sumDuration)
-      })
+      this.editorService
+        .updateNewContentV3(_.omit(requestBody, ['resourceType']), this.contentService.parentContent)
+        .subscribe((response: any) => {
+          // tslint:disable-next-line:no-console
+          console.log('duration', response.duration)
+          this.setCourseDuration(isNumber(sumDuration) ? sumDuration.toString() : sumDuration)
+        })
     }
   }
   createResourseContent(name: string, type: string) {
@@ -2520,9 +2588,9 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       this.isPdfOrAudioOrVedioEnabled = false
       let obj: any = {}
       sessionStorage.clear()
-      obj["type"] = 'assessment'
-      obj["name"] = 'assessment'
-      obj["description"] = 'assessment'
+      obj['type'] = 'assessment'
+      obj['name'] = 'assessment'
+      obj['description'] = 'assessment'
       sessionStorage.setItem('assessment', 'true')
       //this.initService.updateAssessment(obj)
       this.setContentType(type)
@@ -2535,9 +2603,9 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       this.isPdfOrAudioOrVedioEnabled = false
       sessionStorage.clear()
       let obj: any = {}
-      obj["type"] = 'assessment'
-      obj["name"] = 'quiz'
-      obj["description"] = 'quiz'
+      obj['type'] = 'assessment'
+      obj['name'] = 'quiz'
+      obj['description'] = 'quiz'
       sessionStorage.setItem('quiz', 'true')
       //this.initService.updateAssessment(obj)
       this.setContentType(type)
@@ -2565,12 +2633,11 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
     this.showChildrenMap[module.identifier] = !this.showChildrenMap[module.identifier]
   }
 
-
   async addResModule(modID: string, courseID: string) {
     this.clearForm()
-    this.addResourceModule["module"] = true
-    this.addResourceModule["modID"] = modID
-    this.addResourceModule["courseID"] = courseID
+    this.addResourceModule['module'] = true
+    this.addResourceModule['modID'] = modID
+    this.addResourceModule['courseID'] = courseID
     //this.addIndependentResource()
     this.showAddModuleForm = true
     this.isResourceTypeEnabled = true
@@ -2584,7 +2651,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
   async addIndependentResource() {
     const dialogRef = this.dialog.open(UserIndexConfirmComponent, {
       width: '420px',
-      data: { 'message': 'You are adding resource outside the module. Would you like to go ahead?', 'id': this.contentService.parentContent },
+      data: { message: 'You are adding resource outside the module. Would you like to go ahead?', id: this.contentService.parentContent },
     })
     dialogRef.afterClosed().subscribe(async result => {
       console.log(result)
@@ -2593,9 +2660,9 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         this.loader.changeLoad.next(true)
 
         this.clearForm()
-        this.addResourceModule["module"] = false
-        this.addResourceModule["modID"] = this.courseData.identifier
-        this.addResourceModule["courseID"] = this.courseData.identifier
+        this.addResourceModule['module'] = false
+        this.addResourceModule['modID'] = this.courseData.identifier
+        this.addResourceModule['courseID'] = this.courseData.identifier
         this.showAddModuleForm = true
         this.isResourceTypeEnabled = true
 
@@ -2604,25 +2671,21 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         })
         this.editItem = ''
         this.loader.changeLoad.next(false)
-
       } else {
         dialogRef.close()
         this.showAddModuleForm = false
       }
     })
-
   }
 
   changeToDefaultImg($event: any) {
-    $event.target.src = this._configurationsService.instanceConfig
-      ? this._configurationsService.instanceConfig.logos.defaultContent
-      : ''
+    $event.target.src = this._configurationsService.instanceConfig ? this._configurationsService.instanceConfig.logos.defaultContent : ''
   }
 
   async editContent(content: any) {
     this.currentCourseId = content.identifier
-    console.log("content", content)
-    console.log("this.currentCourseId", this.currentCourseId)
+    console.log('content', content)
+    console.log('this.currentCourseId', this.currentCourseId)
     this.loader.changeLoad.next(true)
     if (content.contentType !== 'CourseUnit') {
       this.loader.changeLoad.next(true)
@@ -2633,7 +2696,6 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         this.loader.changeLoad.next(false)
       })
     }
-
 
     this.editItem = content.identifier
     this.currentContent = content.identifier
@@ -2677,7 +2739,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       this.isAssessmentOrQuizEnabled = false
       this.editResourceLinks = content.artifactUrl ? content.artifactUrl : ''
       // tslint:disable-next-line:no-console
-      console.log("link content", this.isLinkEnabled, this.editResourceLinks)
+      console.log('link content', this.isLinkEnabled, this.editResourceLinks)
       //this.subAction({ type: 'editContent', identifier: this.content.identifier, nodeClicked: false })
     } else if (content.mimeType == 'application/pdf') {
       this.uploadIcon = 'cbp-assets/images/pdf-icon.png'
@@ -2706,7 +2768,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
     } else if (content.mimeType === 'video/mp4') {
       this.activeTabIndex = 0
       // tslint:disable-next-line:no-console
-      console.log("this.uploadFile", content.artifactUrl)
+      console.log('this.uploadFile', content.artifactUrl)
       this.uploadFileName = content.artifactUrl ? content.artifactUrl.split('/').pop() : ''
       this.uploadVideoUrl = content.artifactUrl ? content.artifactUrl : ''
       this.cdr.detectChanges() // Ensure template updates before manipulating the DOM
@@ -2739,16 +2801,18 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       this.valueSvc.isXSmall$.subscribe(isMobile => (this.isMobile = isMobile))
       //this.subAction({ type: 'editContent', identifier: this.content.identifier, nodeClicked: false })
     } else {
-      if (content.mimeType == "application/json") {
-        const fileData = ((content.artifactUrl || content.downloadUrl) ?
-          this.quizResolverSvc.getJSON(this.generateUrl(content.artifactUrl || content.downloadUrl)) : of({} as any))
+      if (content.mimeType == 'application/json') {
+        const fileData =
+          content.artifactUrl || content.downloadUrl
+            ? this.quizResolverSvc.getJSON(this.generateUrl(content.artifactUrl || content.downloadUrl))
+            : of({} as any)
         fileData.subscribe(jsonResponse => {
           if (jsonResponse && Object.keys(jsonResponse).length > 1) {
             if (jsonResponse) {
               if (jsonResponse.isAssessment) {
                 this.initService.isAssessmentOrQuizAction(jsonResponse.isAssessment)
                 if (jsonResponse.isAssessment === true) {
-                  this.assessmentOrQuizName = "Assessment"
+                  this.assessmentOrQuizName = 'Assessment'
                 }
               }
             }
@@ -2774,7 +2838,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
     }
   }
   editAssessmentRes(content?: any) {
-    console.log("content module", content, this.moduleName, this.isSelfAssessment)
+    console.log('content module', content, this.moduleName, this.isSelfAssessment)
     // Show the global "Please wait..." loader while the assessment/quiz builder
     // mounts and loads — otherwise there's a blank page during the transition.
     // The quiz component clears this loader once its UI is ready (and has a 3s
@@ -2783,7 +2847,9 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
     if (this.isSelfAssessment) {
       // Defer quiz mount by one task so Angular gets a render cycle to paint the
       // overlay before the quiz component mounts.
-      setTimeout(() => { this.initService.updateAssessment(content) }, 50)
+      setTimeout(() => {
+        this.initService.updateAssessment(content)
+      }, 50)
       return
     }
     if (content.name !== this.moduleName && this.moduleName && !this.isSelfAssessment) {
@@ -2794,8 +2860,8 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
 
       const body = {
         request: {
-          content: requestBody
-        }
+          content: requestBody,
+        },
       }
       this.editorService.updateNewContentV3(body, this.content.identifier).subscribe(
         async (info: any) => {
@@ -2811,25 +2877,26 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         },
         () => {
           this.loader.changeLoad.next(false)
-        })
+        },
+      )
     } else {
       // Defer quiz mount by one task so the overlay paints first.
-      setTimeout(() => { this.initService.updateAssessment(content) }, 50)
+      setTimeout(() => {
+        this.initService.updateAssessment(content)
+      }, 50)
     }
-
-
   }
 
   async addAssessment() {
     this.loader.changeLoadState(true)
 
     this.viewMode = 'assessment'
-    this.addResourceModule["viewMode"] = 'assessment'
+    this.addResourceModule['viewMode'] = 'assessment'
     let obj: any = {}
-    obj["type"] = 'assessment'
-    obj["name"] = 'assessment'
-    obj["description"] = 'assessment'
-    console.log("obj: " + JSON.stringify(obj))
+    obj['type'] = 'assessment'
+    obj['name'] = 'assessment'
+    obj['description'] = 'assessment'
+    console.log('obj: ' + JSON.stringify(obj))
     if (this.resourceLinkForm.value.name) {
       const requestBody: any = {
         name: this.resourceLinkForm.value.name,
@@ -2838,38 +2905,27 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
 
       const body = {
         request: {
-          content: requestBody
-        }
+          content: requestBody,
+        },
       }
-      this.editorService.updateNewContentV3(body, this.currentContent).subscribe(
-        async (info: any) => {
-          // tslint:disable-next-line:no-console
-          console.log('info', info, this.content)
-          if (info) {
-            this.editItem = ''
-            this.initService.updateAssessment(obj)
-            this.loader.changeLoadState(false)
-          }
-        })
+      this.editorService.updateNewContentV3(body, this.currentContent).subscribe(async (info: any) => {
+        // tslint:disable-next-line:no-console
+        console.log('info', info, this.content)
+        if (info) {
+          this.editItem = ''
+          this.initService.updateAssessment(obj)
+          this.loader.changeLoadState(false)
+        }
+      })
     } else {
       this.initService.updateAssessment(obj)
     }
   }
 
-
   uploadAppIcon(file: File) {
     const formdata = new FormData()
     const fileName = file.name.replace(/[^A-Za-z0-9.]/g, '')
-    if (
-      !(
-        IMAGE_SUPPORT_TYPES.indexOf(
-          `.${fileName
-            .toLowerCase()
-            .split('.')
-            .pop()}`,
-        ) > -1
-      )
-    ) {
+    if (!(IMAGE_SUPPORT_TYPES.indexOf(`.${fileName.toLowerCase().split('.').pop()}`) > -1)) {
       this.snackBar.openFromComponent(NotificationComponent, {
         data: {
           type: Notify.INVALID_FORMAT,
@@ -2929,145 +2985,145 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
             },
           }
 
-          this.http
-            .post<NSApiRequest.ICreateMetaRequest>(
-              `${AUTHORING_BASE}content/v3/create`,
-              requestBody,
-            )
-            .subscribe(
-              (meta: any) => {
-                // return data.result.identifier
-                this.uploadService
-                  .upload(formdata, {
-                    contentId: meta.result.identifier,
-                    contentType: CONTENT_BASE_STATIC,
-                  })
+          this.http.post<NSApiRequest.ICreateMetaRequest>(`${AUTHORING_BASE}content/v3/create`, requestBody).subscribe((meta: any) => {
+            // return data.result.identifier
+            this.uploadService
+              .upload(formdata, {
+                contentId: meta.result.identifier,
+                contentType: CONTENT_BASE_STATIC,
+              })
 
-                  .subscribe(
-                    data => {
-                      if (data && data.name !== 'Error') {
-                        this.loader.changeLoad.next(false)
-                        //this.moduleForm.controls.appIcon.setValue(data.artifactUrl)
-                        //this.courseData.thumbnail = data.artifactUrl
-                        let meta: any = {}
-                        let requestBody: any
-                        // this.editorService.readcontentV3(this.courseData.identifier).subscribe((resData: any) => {
-                        //   console.log(resData)
-                        // })
+              .subscribe(data => {
+                if (data && data.name !== 'Error') {
+                  this.loader.changeLoad.next(false)
+                  //this.moduleForm.controls.appIcon.setValue(data.artifactUrl)
+                  //this.courseData.thumbnail = data.artifactUrl
+                  let meta: any = {}
+                  let requestBody: any
+                  // this.editorService.readcontentV3(this.courseData.identifier).subscribe((resData: any) => {
+                  //   console.log(resData)
+                  // })
 
-                        meta["appIcon"] = data.artifactUrl
-                        meta["thumbnail"] = data.content_url
-                        this.thumbnail = data.content_url
-                        meta["versionKey"] = this.courseData.versionKey
-                        this.contentService.currentContentData = meta
+                  meta['appIcon'] = data.artifactUrl
+                  meta['thumbnail'] = data.content_url
+                  this.thumbnail = data.content_url
+                  meta['versionKey'] = this.courseData.versionKey
+                  this.contentService.currentContentData = meta
 
-                        this.contentService.currentContentID = this.content.identifier
-                        this.contentService.setUpdatedMeta(meta, this.content.identifier || data.identifier)
-                        // tslint:disable-next-line:no-console
+                  this.contentService.currentContentID = this.content.identifier
+                  this.contentService.setUpdatedMeta(meta, this.content.identifier || data.identifier)
+                  // tslint:disable-next-line:no-console
 
-                        console.log(meta)
-                        requestBody = {
-                          request: {
-                            content: meta
-                          }
-                        }
-                        this.contentService.setUpdatedMeta(meta, this.content.identifier)
-                        //this.initService.uploadData('thumbnail')
-                        if (this.content.contentType === 'Resource' || this.content.contentType === 'Course') {
-                          this.editorService.updateNewContentV3(requestBody, this.content.identifier).subscribe(
-                            (info: any) => {
-                              // tslint:disable-next-line:no-console
-                              console.log('info', info)
-                              if (info) {
-                                this.editorService.readcontentV3(this.contentService.parentContent).subscribe((data: any) => {
-                                  this.courseData = data
-                                })
-                                //this.update()
-                              }
-                            })
-                        } else {
-                          this.update()
-                        }
+                  console.log(meta)
+                  requestBody = {
+                    request: {
+                      content: meta,
+                    },
+                  }
+                  this.contentService.setUpdatedMeta(meta, this.content.identifier)
+                  //this.initService.uploadData('thumbnail')
+                  if (this.content.contentType === 'Resource' || this.content.contentType === 'Course') {
+                    this.editorService.updateNewContentV3(requestBody, this.content.identifier).subscribe((info: any) => {
+                      // tslint:disable-next-line:no-console
+                      console.log('info', info)
+                      if (info) {
+                        this.editorService.readcontentV3(this.contentService.parentContent).subscribe((data: any) => {
+                          this.courseData = data
+                        })
+                        //this.update()
                       }
                     })
+                  } else {
+                    this.update()
+                  }
+                }
               })
+          })
         }
-      }
+      },
     })
   }
   findInvalidEntriesIndices(data: any): any[] {
     const seenTimestamps = new Set<number>()
-    return data.map((item: any, index: number) => {
-      const result: any = { index }
+    return data
+      .map((item: any, index: number) => {
+        const result: any = { index }
 
-      // Validate the timestamp against the ACTUAL video length (read from the browser)
-      // when available, falling back to the manually-entered Duration. This stops a quiz
-      // timestamp being accepted just because the typed Duration is larger than the clip.
-      const maxAllowedSeconds = this.videoActualDuration != null ? this.videoActualDuration : this.timeToSeconds()
-      if (item.timestampInSeconds > maxAllowedSeconds) {
-        result.invalidTime = true
-      } else if (item.timestampInSeconds === 0) {
-        result.invalidSec = true
-      } else {
-        result.invalidTime = false
-      }
-      // Check for duplicate timestamps
-      if (seenTimestamps.has(item.timestampInSeconds)) {
-        result.duplicateTimestamp = true
-      } else {
-        seenTimestamps.add(item.timestampInSeconds)
-      }
-      // Check all questions
-      const hasInvalidQuestion = item.question.some((q: { text: any; options: any[] }) => {
-        // Check if question text is empty
-        if (!q.text) {
-          result.invalidQuestion = true
-          return true
+        // Validate the timestamp against the ACTUAL video length (read from the browser)
+        // when available, falling back to the manually-entered Duration. This stops a quiz
+        // timestamp being accepted just because the typed Duration is larger than the clip.
+        const maxAllowedSeconds = this.videoActualDuration != null ? this.videoActualDuration : this.timeToSeconds()
+        if (item.timestampInSeconds > maxAllowedSeconds) {
+          result.invalidTime = true
+        } else if (item.timestampInSeconds === 0) {
+          result.invalidSec = true
+        } else {
+          result.invalidTime = false
         }
+        // Check for duplicate timestamps
+        if (seenTimestamps.has(item.timestampInSeconds)) {
+          result.duplicateTimestamp = true
+        } else {
+          seenTimestamps.add(item.timestampInSeconds)
+        }
+        // Check all questions
+        const hasInvalidQuestion = item.question.some((q: { text: any; options: any[] }) => {
+          // Check if question text is empty
+          if (!q.text) {
+            result.invalidQuestion = true
+            return true
+          }
 
-        // Check if options array is empty or contains invalid options (empty text)
-        // Check if options array contains fewer than 2 options or has empty option text
-        const hasEmptyOptionText = q.options.some((opt: { text: any }) => !opt.text)
-        if (!q.options || hasEmptyOptionText) {
-          result.invalidOption = true
-          return true
-        }
-        if (q.options.length < 2) {
-          result.invalidMinOption = true
-          return true
-        }
-        // Ensure at least one option is correct
-        const isCorrectInvalid = !q.options.some((opt: { isCorrect: any }) => opt.isCorrect)
-        if (isCorrectInvalid) {
-          result.invalidIsCorrect = true
-          return true
-        }
-        const hasMissingAnswerInfo = q.options.some((opt: { answerInfo: any }) => {
-          return !opt.answerInfo
+          // Check if options array is empty or contains invalid options (empty text)
+          // Check if options array contains fewer than 2 options or has empty option text
+          const hasEmptyOptionText = q.options.some((opt: { text: any }) => !opt.text)
+          if (!q.options || hasEmptyOptionText) {
+            result.invalidOption = true
+            return true
+          }
+          if (q.options.length < 2) {
+            result.invalidMinOption = true
+            return true
+          }
+          // Ensure at least one option is correct
+          const isCorrectInvalid = !q.options.some((opt: { isCorrect: any }) => opt.isCorrect)
+          if (isCorrectInvalid) {
+            result.invalidIsCorrect = true
+            return true
+          }
+          const hasMissingAnswerInfo = q.options.some((opt: { answerInfo: any }) => {
+            return !opt.answerInfo
+          })
+          if (hasMissingAnswerInfo) {
+            result.invalidAnswerInfo = true
+            return true
+          }
+
+          return false
         })
-        if (hasMissingAnswerInfo) {
-          result.invalidAnswerInfo = true
-          return true
+        if (
+          hasInvalidQuestion ||
+          result.invalidOption ||
+          result.invalidIsCorrect ||
+          result.duplicateTimestamp ||
+          result.invalidAnswerInfo ||
+          result.invalidTime ||
+          result.invalidSec
+        ) {
+          return result
         }
 
-        return false
+        return null
       })
-      if (hasInvalidQuestion || result.invalidOption || result.invalidIsCorrect || result.duplicateTimestamp || result.invalidAnswerInfo || result.invalidTime || result.invalidSec) {
-        return result
-      }
-
-      return null
-    }).filter((entry: any) => entry !== null)[0] // Return the first object with issues
+      .filter((entry: any) => entry !== null)[0] // Return the first object with issues
   }
-
-
 
   notifyInvalid(invalid: any) {
     if (invalid.invalidTime) {
       this.snackBar.openFromComponent(NotificationComponent, {
         data: {
           type: Notify.DURATION_CANT_BE_GREATER,
-          data: invalid
+          data: invalid,
         },
         duration: NOTIFICATION_TIME * 1000,
       })
@@ -3076,7 +3132,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       this.snackBar.openFromComponent(NotificationComponent, {
         data: {
           type: Notify.DUPLICATE_TIMESTAMP,
-          data: invalid
+          data: invalid,
         },
         duration: NOTIFICATION_TIME * 1000,
       })
@@ -3085,7 +3141,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       this.snackBar.openFromComponent(NotificationComponent, {
         data: {
           type: Notify.QUESTION_DURATION_CANT_BE_0,
-          data: invalid
+          data: invalid,
         },
         duration: NOTIFICATION_TIME * 1000,
       })
@@ -3094,7 +3150,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       this.snackBar.openFromComponent(NotificationComponent, {
         data: {
           type: Notify.INVALID_QUESTION,
-          data: invalid
+          data: invalid,
         },
         duration: NOTIFICATION_TIME * 1000,
       })
@@ -3103,7 +3159,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       this.snackBar.openFromComponent(NotificationComponent, {
         data: {
           type: Notify.INVALID_OPTION,
-          data: invalid
+          data: invalid,
         },
         duration: NOTIFICATION_TIME * 1000,
       })
@@ -3112,7 +3168,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       this.snackBar.openFromComponent(NotificationComponent, {
         data: {
           type: Notify.INVALID_ANSWER_INFO,
-          data: invalid
+          data: invalid,
         },
         duration: NOTIFICATION_TIME * 1000,
       })
@@ -3121,7 +3177,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       this.snackBar.openFromComponent(NotificationComponent, {
         data: {
           type: Notify.INVALID_MIN_OPTION,
-          data: invalid
+          data: invalid,
         },
         duration: NOTIFICATION_TIME * 1000,
       })
@@ -3130,20 +3186,27 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       this.snackBar.openFromComponent(NotificationComponent, {
         data: {
           type: Notify.INVALID_IS_CORRECT,
-          data: invalid
+          data: invalid,
         },
         duration: NOTIFICATION_TIME * 1000,
       })
     }
   }
 
+  // "Show Correct Answer Popup" applies ONLY to an Assessment resource — never a
+  // Quiz (isAssessment === false), a Self Assessment (isSelfAssessment), or any
+  // other resource type (pdf/audio/video/link). Gate on the assessment mimeType so
+  // a stale `isAssessment` flag leaking onto a non-assessment resource can't show it.
+  get isAssessmentResource(): boolean {
+    return this.content?.mimeType === 'application/json' && !!this.content?.isAssessment && !this.isSelfAssessment
+  }
 
   async saveDetails(name: string, topicDescription: string, thumbnail: string, isNewTab: any, isShowBtn: any, content: string) {
     let meta: any = {}
     let requestBody: any
     let invalid: any = this.findInvalidEntriesIndices(this.videoQuestions)
 
-    console.log("this.videoQuestions", invalid, this.videoQuestions)
+    console.log('this.videoQuestions', invalid, this.videoQuestions)
     if (invalid) {
       this.notifyInvalid(invalid)
     } else {
@@ -3161,37 +3224,34 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
           duration: NOTIFICATION_TIME * 1000,
         })
       } else {
-        if (isNewTab)
-          iframeSupported = 'Yes'
-        else
-          iframeSupported = 'No'
-        if (isShowBtn)
-          showDownloadBtn = 'Yes'
-        else
-          showDownloadBtn = 'No'
+        if (isNewTab) iframeSupported = 'Yes'
+        else iframeSupported = 'No'
+        if (isShowBtn) showDownloadBtn = 'Yes'
+        else showDownloadBtn = 'No'
         if (this.acceptType === '.zip') {
           iframeSupported = 'Yes'
         }
-        meta["appIcon"] = thumbnail
-        meta["thumbnail"] = thumbnail
-        meta["versionKey"] = this.updatedVersionKey
-        meta["instructions"] = topicDescription
-        meta["description"] = topicDescription
-        meta["name"] = name ? name.trim() : name
-        meta["duration"] = this.timeToSeconds().toString()
+        meta['appIcon'] = thumbnail
+        meta['thumbnail'] = thumbnail
+        meta['versionKey'] = this.updatedVersionKey
+        meta['instructions'] = topicDescription
+        meta['description'] = topicDescription
+        meta['name'] = name ? name.trim() : name
+        meta['duration'] = this.timeToSeconds().toString()
         // meta["gatingEnabled"] = isGating
-        meta["isIframeSupported"] = iframeSupported
-        meta["showDownloadBtn"] = showDownloadBtn
-        // Save isCorrectAnswerPopUp for assessments
-        if (this.content && this.content.isAssessment && !this.isSelfAssessment && this.content.isCorrectAnswerPopUp !== undefined) {
-          meta["isCorrectAnswerPopUp"] = this.content.isCorrectAnswerPopUp
+        meta['isIframeSupported'] = iframeSupported
+        meta['showDownloadBtn'] = showDownloadBtn
+        // Save isCorrectAnswerPopUp for assessments only
+        if (this.isAssessmentResource && this.content.isCorrectAnswerPopUp !== undefined) {
+          meta['isCorrectAnswerPopUp'] = this.content.isCorrectAnswerPopUp
         }
 
-
-        var res = this.editResourceLinks.match(/^(?:https?:\/\/)(?:www\.)(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})(?:\S+)?$/)
+        var res = this.editResourceLinks.match(
+          /^(?:https?:\/\/)(?:www\.)(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})(?:\S+)?$/,
+        )
         // var res = this.editResourceLinks.match(/(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g)
         if (res !== null && this.content.mimeType === 'text/x-url') {
-          meta["artifactUrl"] = this.editResourceLinks
+          meta['artifactUrl'] = this.editResourceLinks
         }
         if (res == null && this.content.mimeType === 'text/x-url') {
           this.snackBar.openFromComponent(NotificationComponent, {
@@ -3204,7 +3264,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
           if (name.trim() === '') {
             this.snackBar.openFromComponent(NotificationComponent, {
               data: {
-                type: (this.content.contentType === 'Resource' ? Notify.INVALID_RESOURCE_NAME : Notify.INVALID_MODULE_NAME),
+                type: this.content.contentType === 'Resource' ? Notify.INVALID_RESOURCE_NAME : Notify.INVALID_MODULE_NAME,
               },
               duration: NOTIFICATION_TIME * 1000,
             })
@@ -3213,8 +3273,8 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
             this.contentService.currentContentID = this.content.identifier
             requestBody = {
               request: {
-                content: meta
-              }
+                content: meta,
+              },
             }
 
             this.contentService.setUpdatedMeta(meta, this.content.identifier)
@@ -3223,19 +3283,18 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
                 // this.removeEmptyQuestions()
                 meta.videoQuestions = this.videoQuestions
               }
-              console.log("this.questions", this.videoQuestions)
-              this.editorService.updateNewContentV3(requestBody, this.content.identifier).subscribe(
-                async (info: any) => {
+              console.log('this.questions', this.videoQuestions)
+              this.editorService.updateNewContentV3(requestBody, this.content.identifier).subscribe(async (info: any) => {
+                // tslint:disable-next-line:no-console
+                console.log('info', info)
+                if (info) {
+                  let result = await this.update()
                   // tslint:disable-next-line:no-console
-                  console.log('info', info)
-                  if (info) {
-                    let result = await this.update()
-                    // tslint:disable-next-line:no-console
-                    console.log(result)
-                    this.clearForm()
-                    this.editItem = ''
-                  }
-                })
+                  console.log(result)
+                  this.clearForm()
+                  this.editItem = ''
+                }
+              })
             } else {
               let result = await this.update()
               // tslint:disable-next-line:no-console
@@ -3246,22 +3305,26 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
           }
         }
       }
-
     }
-
   }
 
   generateUrl(oldUrl: any) {
     //const chunk = oldUrl.split('/')
     //const newChunk = environment.azureHost.split('/')
     // @ts-ignore: Unreachable code error
-    this.bucket = window["env"]["azureBucket"]
+    this.bucket = window['env']['azureBucket']
     if (oldUrl.includes(this.bucket)) {
       return oldUrl
     }
-
   }
-  jsonVerify(s: string) { try { JSON.parse(s); return true } catch (e) { return false } }
+  jsonVerify(s: string) {
+    try {
+      JSON.parse(s)
+      return true
+    } catch (e) {
+      return false
+    }
+  }
 
   routerValuesCall() {
     this.contentService.changeActiveCont.subscribe(data => {
@@ -3274,7 +3337,6 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
 
     if (this.activateRoute.parent && this.activateRoute.parent.parent) {
       this.activateRoute.parent.parent.data.subscribe(data => {
-
         this.courseName = data.contents[0].content.name
 
         const contentDataMap = new Map<string, NSContent.IContentMeta>()
@@ -3291,9 +3353,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         contentDataMap.forEach(content => this.contentService.setOriginalMeta(content))
         const currentNode = (this.storeService.lexIdMap.get(this.currentContent) as number[])[0]
         this.currentParentId = this.currentContent
-        this.storeService.treeStructureChange.next(
-          this.storeService.flatNodeMap.get(currentNode) as IContentNode,
-        )
+        this.storeService.treeStructureChange.next(this.storeService.flatNodeMap.get(currentNode) as IContentNode)
         this.storeService.currentParentNode = currentNode
         this.storeService.currentSelectedNode = currentNode
         let newCreatedNode = 0
@@ -3302,8 +3362,12 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
           newCreatedNode = (this.storeService.lexIdMap.get(newCreatedLexid) as number[])[0]
           this.storeService.selectedNodeChange.next(newCreatedNode)
         }
-        if (data.contents[0] && data.contents[0].content && data.contents[0].content.children[0] &&
-          data.contents[0].content.children[0].identifier) {
+        if (
+          data.contents[0] &&
+          data.contents[0].content &&
+          data.contents[0].content.children[0] &&
+          data.contents[0].content.children[0].identifier
+        ) {
           this.storeService.selectedNodeChange.next(data.contents[0].content.children[0].identifier)
         }
       })
@@ -3313,7 +3377,6 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         if (urlParam === 'collection') {
           this.headerService.showCreatorHeader(this.courseName)
         }
-
       })
     }
   }
@@ -3328,11 +3391,12 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
 
     if (
       (Object.keys(updatedContent).length &&
-        (Object.values(updatedContent).length && JSON.stringify(Object.values(updatedContent)[0]) !== '{}')) ||
+        Object.values(updatedContent).length &&
+        JSON.stringify(Object.values(updatedContent)[0]) !== '{}') ||
       Object.keys(this.storeService.changedHierarchy).length
     ) {
       this.loader.changeLoad.next(true)
-      if (this.contentService.getUpdatedMeta(this.currentCourseId).contentType !== "CourseUnit") {
+      if (this.contentService.getUpdatedMeta(this.currentCourseId).contentType !== 'CourseUnit') {
         this.versionID = await this.editorService.readcontentV3(this.currentCourseId).toPromise()
         this.versionKey = this.contentService.getUpdatedMeta(this.currentCourseId)
       }
@@ -3349,9 +3413,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         (error: any) => {
           if (error.status === 409) {
             const errorMap = new Map<string, NSContent.IContentMeta>()
-            Object.keys(this.contentService.originalContent).forEach(v =>
-              errorMap.set(v, this.contentService.originalContent[v]),
-            )
+            Object.keys(this.contentService.originalContent).forEach(v => errorMap.set(v, this.contentService.originalContent[v]))
             this.isError = true
             const dialog = this.dialog.open(ErrorParserComponent, {
               width: '80vw',
@@ -3364,15 +3426,11 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
             dialog.afterClosed().subscribe(v => {
               if (v) {
                 if (typeof v === 'string') {
-                  this.storeService.selectedNodeChange.next(
-                    (this.storeService.lexIdMap.get(v) as number[])[0],
-                  )
+                  this.storeService.selectedNodeChange.next((this.storeService.lexIdMap.get(v) as number[])[0])
                   this.contentService.changeActiveCont.next(v)
                 } else {
                   this.storeService.selectedNodeChange.next(v)
-                  this.contentService.changeActiveCont.next(
-                    this.storeService.uniqueIdMap.get(v) as string,
-                  )
+                  this.contentService.changeActiveCont.next(this.storeService.uniqueIdMap.get(v) as string)
                 }
               }
               this.isError = false
@@ -3385,7 +3443,8 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
             },
             duration: NOTIFICATION_TIME * 1000,
           })
-        })
+        },
+      )
     }
   }
   async update() {
@@ -3427,7 +3486,6 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
           if (resourceDurat.length > 0) {
             sumDuration = resourceDurat.reduce((a: any, b: any) => a + b)
           }
-
         }
         let requestBody: any
         // tslint:disable-next-line:no-console
@@ -3436,18 +3494,18 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
           requestBody = {
             request: {
               content: {
-                duration: isNumber(sumDuration) ?
-                  sumDuration.toString() : sumDuration,
-                versionKey: data.versionKey
+                duration: isNumber(sumDuration) ? sumDuration.toString() : sumDuration,
+                versionKey: data.versionKey,
               },
-            }
+            },
           }
-          this.editorService.updateNewContentV3(_.omit(requestBody, ['resourceType']), this.contentService.parentContent).subscribe((response: any) => {
-            // tslint:disable-next-line:no-console
-            console.log('duration', response.duration)
-            this.setCourseDuration(isNumber(sumDuration) ?
-              sumDuration.toString() : sumDuration)
-          })
+          this.editorService
+            .updateNewContentV3(_.omit(requestBody, ['resourceType']), this.contentService.parentContent)
+            .subscribe((response: any) => {
+              // tslint:disable-next-line:no-console
+              console.log('duration', response.duration)
+              this.setCourseDuration(isNumber(sumDuration) ? sumDuration.toString() : sumDuration)
+            })
         }
 
         if (this.courseData && this.courseData.children.length >= 2) {
@@ -3460,10 +3518,9 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         this.loader.changeLoad.next(false)
         this.snackBar.openFromComponent(NotificationComponent, {
           data: {
-            type: Notify.SUCCESS
+            type: Notify.SUCCESS,
           },
           duration: NOTIFICATION_TIME * 500,
-
         })
         this.contentService.resetOriginalMetaWithHierarchy(data)
         // tslint:disable-next-line: align
@@ -3506,14 +3563,14 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       requestBody = {
         request: {
           content: tempUpdateContent,
-        }
+        },
       }
       requestBody.request.content = this.contentService.cleanProperties(requestBody.request.content)
       if (requestBody.request.content.duration === 0 || requestBody.request.content.duration) {
         // tslint:disable-next-line:max-line-length
-        requestBody.request.content.duration =
-          isNumber(requestBody.request.content.duration) ?
-            requestBody.request.content.duration.toString() : requestBody.request.content.duration
+        requestBody.request.content.duration = isNumber(requestBody.request.content.duration)
+          ? requestBody.request.content.duration.toString()
+          : requestBody.request.content.duration
       }
 
       if (requestBody.request.content.category) {
@@ -3600,7 +3657,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
               // })
             })
             this.contentService.upDatedContent = {}
-          })
+          }),
         )
       } else {
         if (tempUpdateContent.category === 'Course') {
@@ -3617,7 +3674,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
                 // })
               })
               this.contentService.upDatedContent = {}
-            })
+            }),
           )
         }
       }
@@ -3634,7 +3691,6 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
 
     return this.editorService.updateContentV4(requestBodyV2).pipe(
       tap(() => {
-
         this.storeService.changedHierarchy = {}
         Object.keys(this.contentService.upDatedContent).forEach(async id => {
           this.contentService.resetOriginalMeta(this.contentService.upDatedContent[id], id)
@@ -3646,10 +3702,9 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         this.contentService.upDatedContent = {}
       }),
     )
-
   }
 
-  subAction(event: { type: string; identifier: string, nodeClicked?: boolean }) {
+  subAction(event: { type: string; identifier: string; nodeClicked?: boolean }) {
     this.contentService.changeActiveCont.next(event.identifier)
     switch (event.type) {
       case 'editContent':
@@ -3667,15 +3722,18 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
           }
           // this.resourceLinkForm.controls.name.setValue(content.name)
         }
-        const isCreator = (this._configurationsService.userProfile
-          && this._configurationsService.userProfile.userId === content.createdBy)
-          ? true : false
+        const isCreator =
+          this._configurationsService.userProfile && this._configurationsService.userProfile.userId === content.createdBy ? true : false
         this.checkCreator = isCreator
         // const isCreator = (this.configSvc.userProfile
         //   && this.configSvc.userProfile.userId === content.createdBy)
         //   ? true : false
         // this.checkCreator = isCreator
-        if (['application/pdf', 'application/x-mpegURL', 'application/vnd.ekstep.html-archive', 'audio/mpeg', 'video/mp4'].includes(content.mimeType)) {
+        if (
+          ['application/pdf', 'application/x-mpegURL', 'application/vnd.ekstep.html-archive', 'audio/mpeg', 'video/mp4'].includes(
+            content.mimeType,
+          )
+        ) {
           this.viewMode = 'upload'
           // } else if (['video/x-youtube', 'text/x-url', 'application/html'].includes(content.mimeType) && content.fileType === 'link') {
         } else if (['video/x-youtube', 'text/x-url', 'application/html'].includes(content.mimeType) && content.fileType === '') {
@@ -3704,7 +3762,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
     if (filetype) {
       this.storeService.uploadFileType.next(filetype)
     }
-    console.log("filetype", filetype)
+    console.log('filetype', filetype)
     let couseCreated = type
     const asSibling = false
     const node = {
@@ -3721,7 +3779,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       topicDescription: '',
       topicName: type.type === 'collection' ? 'Add Module' : 'Resource',
       isAssessment: this.assessment,
-      isCorrectAnswerPopUp: this.assessment && !this.isSelfAssessment ? false : undefined
+      isCorrectAnswerPopUp: this.assessment && !this.isSelfAssessment ? false : undefined,
     }
     if (type.type === 'collection') {
       this.storeService.parentData = this.courseData
@@ -3750,21 +3808,20 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
     // })
     if (isDone) {
       const newCreatedLexid = this.editorService.newCreatedLexid
-      if (this.addResourceModule["module"] === true) {
+      if (this.addResourceModule['module'] === true) {
         let request: any
         request = {
           request: {
-            rootId: this.addResourceModule["courseID"],
-            unitId: this.addResourceModule["modID"],
+            rootId: this.addResourceModule['courseID'],
+            unitId: this.addResourceModule['modID'],
             children: [this.editorService.resourseID],
           },
         }
-        console.log("yes here module", request, this.addResourceModule["modID"])
+        console.log('yes here module', request, this.addResourceModule['modID'])
         //if (this.parentNode[0] !== dropNode.identifier) {
         const result = await this.editorService.resourceToModule(request).toPromise()
         // tslint:disable-next-line:no-console
         console.log(result)
-
 
         await this.editorService.readcontentV3(this.contentService.parentContent).subscribe(async (data: any) => {
           this.courseData = await data
@@ -3778,7 +3835,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
           }
 
           Object.keys(hierarchyData).forEach((ele: any) => {
-            if (ele === this.addResourceModule["modID"]) {
+            if (ele === this.addResourceModule['modID']) {
               hierarchyData[ele].children.push(this.editorService.resourseID)
             }
           })
@@ -3810,12 +3867,12 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         //this.courseData = []
         await this.editorService.readcontentV3(this.contentService.parentContent).subscribe(async (data: any) => {
           this.courseData = await data
-          console.log("data", data)
+          console.log('data', data)
           // this.content.parent = data.identifier
           const hierarchyData = this.storeService.getNewTreeHierarchy(this.courseData)
 
           Object.keys(hierarchyData).forEach((ele: any) => {
-            if (ele === this.addResourceModule["courseID"]) {
+            if (ele === this.addResourceModule['courseID']) {
               hierarchyData[this.editorService.resourseID] = {
                 root: false,
                 name: this.resourseSelected !== 'assessment' ? 'Resource 1' : 'Assessment',
@@ -3848,7 +3905,6 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
             })
           })
         })
-
       }
       if (newCreatedLexid) {
         const newCreatedNode = (this.storeService.lexIdMap.get(newCreatedLexid) as number[])[0]
@@ -3870,23 +3926,17 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
   }
   copyToClipboard(module: any) {
     // tslint:disable-next-line:no-console
-    navigator.clipboard.writeText(module).then().catch(e => console.log(e))
+    navigator.clipboard
+      .writeText(module)
+      .then()
+      .catch(e => console.log(e))
   }
 
   uploadResourceAppIcon(file: File) {
     const formdata = new FormData()
     const fileName = file.name.replace(/[^A-Za-z0-9.]/g, '')
 
-    if (
-      !(
-        IMAGE_SUPPORT_TYPES.indexOf(
-          `.${fileName
-            .toLowerCase()
-            .split('.')
-            .pop()}`,
-        ) > -1
-      )
-    ) {
+    if (!(IMAGE_SUPPORT_TYPES.indexOf(`.${fileName.toLowerCase().split('.').pop()}`) > -1)) {
       this.snackBar.openFromComponent(NotificationComponent, {
         data: {
           type: Notify.INVALID_FORMAT,
@@ -3947,59 +3997,52 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
             },
           }
 
-          this.http
-            .post<NSApiRequest.ICreateMetaRequest>(
-              `${AUTHORING_BASE}content/v3/create`,
-              requestBody,
-            )
-            .subscribe(
-              (meta: any) => {
-                this.uploadService
-                  .upload(formdata, {
-                    contentId: meta.result.identifier,
-                    contentType: CONTENT_BASE_STATIC,
-                  })
-
-                  .subscribe(
-                    data => {
-                      if (data && data.name !== 'Error') {
-                        this.loader.changeLoad.next(false)
-                        this.canUpdate = false
-                        this.resourceLinkForm.controls.appIcon.setValue(this.generateUrl(data.artifactUrl))
-                        this.resourceLinkForm.controls.thumbnail.setValue(this.generateUrl(data.artifactUrl))
-                        this.resourcePdfForm.controls.appIcon.setValue(this.generateUrl(data.artifactUrl))
-                        this.resourcePdfForm.controls.thumbnail.setValue(this.generateUrl(data.artifactUrl))
-                        this.canUpdate = true
-                        // this.data.emit('save')
-                        this.updateStoreData()
-
-                        this.initService.uploadData('thumbnail')
-                        // this.contentForm.controls.posterImage.setValue(data.artifactURL)
-                        this.snackBar.openFromComponent(NotificationComponent, {
-                          data: {
-                            type: Notify.UPLOAD_SUCCESS,
-                          },
-                          duration: NOTIFICATION_TIME * 2000,
-                        })
-                      }
-                      else {
-                        this.loader.changeLoad.next(false)
-                        this.snackBar.open(data.message, undefined, { duration: 2000 })
-                      }
-                    },
-                    () => {
-                      this.loader.changeLoad.next(false)
-                      this.snackBar.openFromComponent(NotificationComponent, {
-                        data: {
-                          type: Notify.UPLOAD_FAIL,
-                        },
-                        duration: NOTIFICATION_TIME * 1000,
-                      })
-                    },
-                  )
+          this.http.post<NSApiRequest.ICreateMetaRequest>(`${AUTHORING_BASE}content/v3/create`, requestBody).subscribe((meta: any) => {
+            this.uploadService
+              .upload(formdata, {
+                contentId: meta.result.identifier,
+                contentType: CONTENT_BASE_STATIC,
               })
+
+              .subscribe(
+                data => {
+                  if (data && data.name !== 'Error') {
+                    this.loader.changeLoad.next(false)
+                    this.canUpdate = false
+                    this.resourceLinkForm.controls.appIcon.setValue(this.generateUrl(data.artifactUrl))
+                    this.resourceLinkForm.controls.thumbnail.setValue(this.generateUrl(data.artifactUrl))
+                    this.resourcePdfForm.controls.appIcon.setValue(this.generateUrl(data.artifactUrl))
+                    this.resourcePdfForm.controls.thumbnail.setValue(this.generateUrl(data.artifactUrl))
+                    this.canUpdate = true
+                    // this.data.emit('save')
+                    this.updateStoreData()
+
+                    this.initService.uploadData('thumbnail')
+                    // this.contentForm.controls.posterImage.setValue(data.artifactURL)
+                    this.snackBar.openFromComponent(NotificationComponent, {
+                      data: {
+                        type: Notify.UPLOAD_SUCCESS,
+                      },
+                      duration: NOTIFICATION_TIME * 2000,
+                    })
+                  } else {
+                    this.loader.changeLoad.next(false)
+                    this.snackBar.open(data.message, undefined, { duration: 2000 })
+                  }
+                },
+                () => {
+                  this.loader.changeLoad.next(false)
+                  this.snackBar.openFromComponent(NotificationComponent, {
+                    data: {
+                      type: Notify.UPLOAD_FAIL,
+                    },
+                    duration: NOTIFICATION_TIME * 1000,
+                  })
+                },
+              )
+          })
         }
-      }
+      },
     })
   }
 
@@ -4008,8 +4051,14 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       const originalMeta = this.contentService.getOriginalMeta(this.editorService.newCreatedLexid)
       if (originalMeta) {
         const currentMeta: NSContent.IContentMeta = JSON.parse(JSON.stringify(this.resourceLinkForm.value))
-        const exemptArray = ['application/quiz', 'application/x-mpegURL', 'audio/mpeg', 'video/mp4',
-          'application/vnd.ekstep.html-archive', 'application/json']
+        const exemptArray = [
+          'application/quiz',
+          'application/x-mpegURL',
+          'audio/mpeg',
+          'video/mp4',
+          'application/vnd.ekstep.html-archive',
+          'application/json',
+        ]
         if (exemptArray.includes(originalMeta.mimeType)) {
           currentMeta.artifactUrl = originalMeta.artifactUrl
           currentMeta.mimeType = originalMeta.mimeType
@@ -4060,8 +4109,6 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
             }
             if (!currentMeta.lang) {
               currentMeta.lang = parentData.lang !== '' ? parentData.lang : currentMeta.lang
-
-
             }
           }
         }
@@ -4077,14 +4124,17 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
 
         Object.keys(currentMeta).map(v => {
           if (
-            v !== 'versionKey' && v !== 'visibility' &&
+            v !== 'versionKey' &&
+            v !== 'visibility' &&
             JSON.stringify(currentMeta[v as keyof NSContent.IContentMeta]) !==
-            JSON.stringify(originalMeta[v as keyof NSContent.IContentMeta]) && v !== 'jobProfile'
+              JSON.stringify(originalMeta[v as keyof NSContent.IContentMeta]) &&
+            v !== 'jobProfile'
           ) {
             if (
               currentMeta[v as keyof NSContent.IContentMeta] ||
               // (this.authInitService.authConfig[v as keyof IFormMeta].type === 'boolean' &&
-              currentMeta[v as keyof NSContent.IContentMeta] === false) {
+              currentMeta[v as keyof NSContent.IContentMeta] === false
+            ) {
               if (v !== 'isIframeSupported') {
                 meta[v as keyof NSContent.IContentMeta] = currentMeta[v as keyof NSContent.IContentMeta]
               }
@@ -4100,9 +4150,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
                     ),
                   )
                 }
-
               }
-
             }
           } else if (v === 'versionKey') {
             meta[v as keyof NSContent.IContentMeta] = originalMeta[v as keyof NSContent.IContentMeta]
@@ -4136,12 +4184,9 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       url: '',
     }
     let type
-    if (file.type == 'video/mp4')
-      type = '.mp4'
-    else if (file.type == 'video/m4v')
-      type = '.m4v'
-    else
-      type = this.acceptType
+    if (file.type == 'video/mp4') type = '.mp4'
+    else if (file.type == 'video/m4v') type = '.m4v'
+    else type = this.acceptType
 
     const fileName = file.name.replace(/[^A-Za-z0-9_.]/g, '')
     if (fileName.toLowerCase().endsWith(type)) {
@@ -4191,9 +4236,9 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
               this.fileUploadCondition.iframe &&
               this.fileUploadCondition.eval &&
               this.fileUploadCondition.preview &&
-              this.fileUploadCondition.externalReference && this.fileUploadCondition.isSubmitPressed
+              this.fileUploadCondition.externalReference &&
+              this.fileUploadCondition.isSubmitPressed
             ) {
-
               this.assignFileValues(file, fileName)
               this.fileUploaded = file
               // this.triggerUpload()
@@ -4206,8 +4251,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
           this.triggerUpload()
         }
       }
-    }
-    else {
+    } else {
       this.snackBar.openFromComponent(NotificationComponent, {
         data: {
           type: Notify.INVALID_FORMAT,
@@ -4225,7 +4269,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
     this.file = file
     this.mimeType = fileName.toLowerCase().endsWith('.pdf')
       ? 'application/pdf'
-      : (fileName.toLowerCase().endsWith('.mp4') || fileName.toLowerCase().endsWith('.m4v'))
+      : fileName.toLowerCase().endsWith('.mp4') || fileName.toLowerCase().endsWith('.m4v')
         ? 'video/mp4'
         : fileName.toLowerCase().endsWith('.zip')
           ? 'application/vnd.ekstep.html-archive'
@@ -4235,8 +4279,8 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
     // tslint:disable-next-line:no-console
     console.log(currentContentData)
     if (
-      (currentContentData.status === 'Live' || currentContentData.prevStatus === 'Live')
-      && this.mimeType !== currentContentData.mimeType
+      (currentContentData.status === 'Live' || currentContentData.prevStatus === 'Live') &&
+      this.mimeType !== currentContentData.mimeType
     ) {
       this.snackBar.openFromComponent(NotificationComponent, {
         data: {
@@ -4246,7 +4290,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       })
       this.fileUploadForm.controls.artifactUrl.setValue(currentContentData.artifactUrl)
       // tslint:disable-next-line:no-console
-      console.log("this.fileUploadForm.controls.artifactUrl", this.fileUploadForm.controls.artifactUrl)
+      console.log('this.fileUploadForm.controls.artifactUrl', this.fileUploadForm.controls.artifactUrl)
       this.mimeType = currentContentData.mimeType
       this.iprChecked()
     } else {
@@ -4259,7 +4303,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
     }
 
     // tslint:disable-next-line:no-console
-    console.log("this.uploadFileName", this.mimeType)
+    console.log('this.uploadFileName', this.mimeType)
     if (this.mimeType == 'application/pdf') {
       this.uploadIcon = 'cbp-assets/images/pdf-icon.png'
     } else if (this.mimeType == 'application/vnd.ekstep.html-archive') {
@@ -4267,8 +4311,6 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
     } else {
       this.uploadIcon = 'cbp-assets/images/video-icon.png'
     }
-
-
   }
 
   iprChecked() {
@@ -4305,12 +4347,9 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         const error = document.getElementById('errorFiles')
         if (error) {
           for (let i = 0; i < error.children.length; i += 1) {
-            error.children[i].innerHTML = error.children[i].innerHTML.replace(
-              /[^A-Za-z0-9./]/g,
-              match => {
-                return `<i style=background-color:red;font-weight:bold>${match}</i>`
-              },
-            )
+            error.children[i].innerHTML = error.children[i].innerHTML.replace(/[^A-Za-z0-9./]/g, match => {
+              return `<i style=background-color:red;font-weight:bold>${match}</i>`
+            })
           }
         }
       })
@@ -4326,7 +4365,8 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
           this.fileUploadCondition.eval &&
           this.fileUploadCondition.preview &&
           this.fileUploadCondition.externalReference &&
-          this.fileUploadCondition.url && this.selectedEntryFile
+          this.fileUploadCondition.url &&
+          this.selectedEntryFile
         ) {
           const fileName = this.fileUploaded.name.replace(/[^A-Za-z0-9_.]/g, '')
           this.uploadFileName = fileName
@@ -4340,9 +4380,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
     this.entryPoint = '/' + `${file}`
   }
   getDuration() {
-    const content = document.createElement(
-      this.mimeType === 'video/mp4' ? 'video' : 'audio',
-    )
+    const content = document.createElement(this.mimeType === 'video/mp4' ? 'video' : 'audio')
     content.preload = 'metadata'
     content.onloadedmetadata = () => {
       window.URL.revokeObjectURL(content.src)
@@ -4352,10 +4390,10 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
   }
 
   async resourcePdfSave() {
-    console.log("this.resource", this.resourcePdfForm, this.videoQuestions)
+    console.log('this.resource', this.resourcePdfForm, this.videoQuestions)
     let invalid: any = this.findInvalidEntriesIndices(this.videoQuestions)
 
-    console.log("this.videoQuestions", invalid, this.videoQuestions)
+    console.log('this.videoQuestions', invalid, this.videoQuestions)
     if (invalid) {
       this.notifyInvalid(invalid)
     } else {
@@ -4384,14 +4422,10 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         } else {
           this.resourcePdfForm.controls.duration.setValue(this.timeToSeconds())
           let iframeSupported, showDownloadBtn
-          if (this.resourcePdfForm.value.isIframeSupported)
-            iframeSupported = 'Yes'
-          else
-            iframeSupported = 'No'
-          if (this.resourcePdfForm.value.showDownloadBtn)
-            showDownloadBtn = 'Yes'
-          else
-            showDownloadBtn = 'No'
+          if (this.resourcePdfForm.value.isIframeSupported) iframeSupported = 'Yes'
+          else iframeSupported = 'No'
+          if (this.resourcePdfForm.value.showDownloadBtn) showDownloadBtn = 'Yes'
+          else showDownloadBtn = 'No'
 
           if (this.acceptType === '.zip') {
             iframeSupported = 'Yes'
@@ -4414,7 +4448,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
             gatingEnabled: this.resourcePdfForm.value.isgatingEnabled,
             duration: this.resourcePdfForm.value.duration,
             versionKey: this.updatedVersionKey,
-            videoQuestions: this.videoQuestions ? this.videoQuestions : []
+            videoQuestions: this.videoQuestions ? this.videoQuestions : [],
           }
           await this.contentService.setUpdatedMeta(rBody, this.currentContent)
           await this.update()
@@ -4438,7 +4472,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       isIframeSupported: '',
       showDownloadBtn: '',
       isgatingEnabled: '',
-      duration: ''
+      duration: '',
     })
 
     this.resourceLinkForm.setValue({
@@ -4450,7 +4484,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       isIframeSupported: '',
       showDownloadBtn: '',
       isgatingEnabled: '',
-      duration: ''
+      duration: '',
     })
 
     this.fileUploadForm.reset()
@@ -4466,7 +4500,6 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
     this.hours = 0
     this.minutes = 0
     this.seconds = 0
-
   }
   dragDrop(type1: any, type2: any, type3: string) {
     console.log(type1, type1.parent, type2, type3)
@@ -4490,8 +4523,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
             if (child1.identifier === data) {
               return child1
             }
-          }
-          )
+          })
         }
       })
       console.log(found1)
@@ -4562,101 +4594,111 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
     console.log(hierarchy, 'init')
 
     if (previousIndex > currentIndex) {
-      if (previousFound && currentFound && previousFound.parent === this.courseData.identifier &&
-        currentFound.parent === this.courseData.identifier && currentFound.contentType === "Resource" && previousFound.contentType === "Resource") {
+      if (
+        previousFound &&
+        currentFound &&
+        previousFound.parent === this.courseData.identifier &&
+        currentFound.parent === this.courseData.identifier &&
+        currentFound.contentType === 'Resource' &&
+        previousFound.contentType === 'Resource'
+      ) {
         console.log('1')
         let parentData = hierarchy[this.courseData.identifier]
-        let prevIndex = parentData["children"].indexOf(previousFound.identifier)
+        let prevIndex = parentData['children'].indexOf(previousFound.identifier)
         //parentData["children"].splice(prevIndex, 0, currentFound.identifier)
         //parentData["children"].splice(prevIndex + 1, 1)
-        let currIndex = parentData["children"].indexOf(currentFound.identifier)
-        parentData["children"].splice(prevIndex, 1)
-        parentData["children"].splice(currIndex, 0, previousFound.identifier)
+        let currIndex = parentData['children'].indexOf(currentFound.identifier)
+        parentData['children'].splice(prevIndex, 1)
+        parentData['children'].splice(currIndex, 0, previousFound.identifier)
         //parentData["children"].splice(prevIndex, 1)
-        console.log(parentData["children"])
+        console.log(parentData['children'])
       } else {
-        let prevContent = previousFound//this.compute(previousFound.identifier)
-        let currentContent = currentFound//this.compute(currentFound.identifier)
-        console.log(prevContent, currentContent, currentFound, currentContent["0"])
+        let prevContent = previousFound //this.compute(previousFound.identifier)
+        let currentContent = currentFound //this.compute(currentFound.identifier)
+        console.log(prevContent, currentContent, currentFound, currentContent['0'])
 
-        let prevData = prevContent["0"] === undefined ? previousFound : prevContent[0]
-        let currData = currentContent["0"] === undefined ? currentFound : currentContent[0]
-        if (currData.contentType === "CourseUnit" && prevData.contentType === 'Resource') {
+        let prevData = prevContent['0'] === undefined ? previousFound : prevContent[0]
+        let currData = currentContent['0'] === undefined ? currentFound : currentContent[0]
+        if (currData.contentType === 'CourseUnit' && prevData.contentType === 'Resource') {
           let cCourseData = hierarchy[currData.identifier]
-          console.log(cCourseData["children"])
-          if (cCourseData["children"].length == 0) {
-            cCourseData["children"].push(previousFound.identifier)
+          console.log(cCourseData['children'])
+          if (cCourseData['children'].length == 0) {
+            cCourseData['children'].push(previousFound.identifier)
           } else {
             let courseData = hierarchy[currData.parent]
-            let cIndex = courseData["children"].indexOf(currData.identifier)
-            courseData["children"].splice(cIndex, 0, previousFound.identifier)
+            let cIndex = courseData['children'].indexOf(currData.identifier)
+            courseData['children'].splice(cIndex, 0, previousFound.identifier)
           }
         } else {
           if (currData.contentType === 'Resource' && prevData.contentType === 'Resource') {
             let cCourseData = hierarchy[currData.parent]
-            let cIndex = cCourseData["children"].indexOf(currData.identifier)
-            cCourseData["children"].splice(cIndex, 0, previousFound.identifier)
+            let cIndex = cCourseData['children'].indexOf(currData.identifier)
+            cCourseData['children'].splice(cIndex, 0, previousFound.identifier)
           }
         }
         if (prevData.contentType === 'Resource') {
           let pCourseData = hierarchy[prevData.parent]
-          let pIndex = pCourseData["children"].lastIndexOf(previousFound.identifier)
-          pCourseData["children"].splice(pIndex, 1)
+          let pIndex = pCourseData['children'].lastIndexOf(previousFound.identifier)
+          pCourseData['children'].splice(pIndex, 1)
         }
         if (prevData.contentType === 'CourseUnit') {
           let pCourseData = hierarchy[prevData.parent]
-          let cIndex = pCourseData["children"].indexOf(currData.identifier)
-          let pIndex = pCourseData["children"].indexOf(previousFound.identifier)
-          pCourseData["children"].splice(pIndex, 1)
-          pCourseData["children"].splice(cIndex, 0, previousFound.identifier)
+          let cIndex = pCourseData['children'].indexOf(currData.identifier)
+          let pIndex = pCourseData['children'].indexOf(previousFound.identifier)
+          pCourseData['children'].splice(pIndex, 1)
+          pCourseData['children'].splice(cIndex, 0, previousFound.identifier)
         }
         console.log(hierarchy)
       }
     } else if (previousIndex <= currentIndex) {
       console.log('2')
-      if (previousFound && currentFound && previousFound.parent === this.courseData.identifier &&
-        currentFound.parent === this.courseData.identifier && currentFound.contentType === "Resource" && previousFound.contentType === "Resource") {
+      if (
+        previousFound &&
+        currentFound &&
+        previousFound.parent === this.courseData.identifier &&
+        currentFound.parent === this.courseData.identifier &&
+        currentFound.contentType === 'Resource' &&
+        previousFound.contentType === 'Resource'
+      ) {
         let parentData = hierarchy[this.courseData.identifier]
-        let prevIndex = parentData["children"].indexOf(previousFound.identifier)
-        let currIndex = parentData["children"].indexOf(currentFound.identifier)
-        parentData["children"].splice(prevIndex, 1)
-        parentData["children"].splice(currIndex, 0, previousFound.identifier)
-        console.log(parentData["children"])
+        let prevIndex = parentData['children'].indexOf(previousFound.identifier)
+        let currIndex = parentData['children'].indexOf(currentFound.identifier)
+        parentData['children'].splice(prevIndex, 1)
+        parentData['children'].splice(currIndex, 0, previousFound.identifier)
+        console.log(parentData['children'])
       } else {
         console.log('here123')
-        let prevContent = previousFound//this.compute(previousFound.identifier)
-        let currentContent = currentFound//this.compute(currentFound.identifier)
+        let prevContent = previousFound //this.compute(previousFound.identifier)
+        let currentContent = currentFound //this.compute(currentFound.identifier)
 
         console.log(prevContent, currentContent)
-        let prevData = prevContent["0"] === undefined ? previousFound : prevContent[0]
-        let currData = currentContent["0"] === undefined ? currentFound : currentContent[0]
+        let prevData = prevContent['0'] === undefined ? previousFound : prevContent[0]
+        let currData = currentContent['0'] === undefined ? currentFound : currentContent[0]
 
-        if (currData.contentType === "CourseUnit" && prevData.contentType === 'Resource') {
-
+        if (currData.contentType === 'CourseUnit' && prevData.contentType === 'Resource') {
           let cCourseData = hierarchy[currData.identifier]
-          console.log(cCourseData["children"])
-          if (cCourseData["children"].length == 0) {
-            cCourseData["children"].push(previousFound.identifier)
+          console.log(cCourseData['children'])
+          if (cCourseData['children'].length == 0) {
+            cCourseData['children'].push(previousFound.identifier)
           } else {
-
             let courseData = hierarchy[currData.parent]
-            let cIndex = courseData["children"].indexOf(currData.identifier)
-            courseData["children"].splice(cIndex, 0, previousFound.identifier)
+            let cIndex = courseData['children'].indexOf(currData.identifier)
+            courseData['children'].splice(cIndex, 0, previousFound.identifier)
             // let cIndex = cCourseData["children"].indexOf(currData.identifier)
             // cCourseData["children"].splice(cIndex, 0, previousFound.identifier)
           }
         } else {
-          if (currData.contentType === 'Resource'
-            && prevData.contentType === 'Resource'
-          ) {
-
+          if (currData.contentType === 'Resource' && prevData.contentType === 'Resource') {
             console.log(identfs[identfs.length - 1] === currData.identifier)
             if (identfs[identfs.length - 1] === currData.identifier) {
               let cCourseData1 = hierarchy[this.courseData.identifier]
               this.loader.changeLoad.next(false)
               const dialogRef = this.dialog.open(UserIndexConfirmComponent, {
                 width: '420px',
-                data: { 'message': 'You are adding resource outside the module. Would you like to go ahead?', 'id': this.contentService.parentContent },
+                data: {
+                  message: 'You are adding resource outside the module. Would you like to go ahead?',
+                  id: this.contentService.parentContent,
+                },
               })
 
               dialogRef.afterClosed().subscribe(async result => {
@@ -4664,21 +4706,21 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
                 this.loader.changeLoad.next(true)
 
                 if (result === 'New') {
-                  cCourseData1["children"].push(prevPosition)
+                  cCourseData1['children'].push(prevPosition)
                   console.log(cCourseData1)
                 } else {
                   let cCourseData2 = hierarchy[currData.parent]
-                  console.log(cCourseData2["children"])
-                  let cIndex = cCourseData2["children"].indexOf(currData.identifier)
+                  console.log(cCourseData2['children'])
+                  let cIndex = cCourseData2['children'].indexOf(currData.identifier)
                   console.log(cIndex)
-                  cCourseData2["children"].splice(cIndex + 1, 0, previousFound.identifier)
+                  cCourseData2['children'].splice(cIndex + 1, 0, previousFound.identifier)
                 }
                 if (prevData.contentType === 'Resource') {
                   let pCourseData = hierarchy[prevData.parent]
-                  console.log(pCourseData["children"])
-                  let pIndex = pCourseData["children"].indexOf(previousFound.identifier)
+                  console.log(pCourseData['children'])
+                  let pIndex = pCourseData['children'].indexOf(previousFound.identifier)
                   console.log(pIndex)
-                  pCourseData["children"].splice(pIndex, 1)
+                  pCourseData['children'].splice(pIndex, 1)
                   console.log(pCourseData)
                 }
                 console.log(hierarchy, 'final123--------')
@@ -4692,7 +4734,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
                   },
                 }
 
-                console.log(requestBodyV2, "data123")
+                console.log(requestBodyV2, 'data123')
                 await this.editorService.updateContentV4(requestBodyV2).subscribe(() => {
                   this.editorService.readcontentV3(this.contentService.parentContent).subscribe((data: any) => {
                     this.loader.changeLoad.next(false)
@@ -4704,28 +4746,25 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
             } else {
               let cCourseData = hierarchy[currData.parent]
               console.log(cCourseData)
-              let cIndex = cCourseData["children"].indexOf(currData.identifier)
+              let cIndex = cCourseData['children'].indexOf(currData.identifier)
               console.log(cIndex)
-              cCourseData["children"].splice(cIndex + 1, 0, previousFound.identifier)
-              console.log(cCourseData["children"], 'pppp')
+              cCourseData['children'].splice(cIndex + 1, 0, previousFound.identifier)
+              console.log(cCourseData['children'], 'pppp')
             }
-
           }
         }
         if (prevData.contentType === 'Resource') {
           let pCourseData = hierarchy[prevData.parent]
-          let pIndex = pCourseData["children"].indexOf(previousFound.identifier)
-          pCourseData["children"].splice(pIndex, 1)
+          let pIndex = pCourseData['children'].indexOf(previousFound.identifier)
+          pCourseData['children'].splice(pIndex, 1)
           console.log(pCourseData)
         }
         if (prevData.contentType === 'CourseUnit') {
-
           let pCourseData = hierarchy[prevData.parent]
-          let cIndex = pCourseData["children"].indexOf(currData.identifier)
-          let pIndex = pCourseData["children"].indexOf(previousFound.identifier)
-          pCourseData["children"].splice(pIndex, 1)
-          pCourseData["children"].splice(cIndex, 0, previousFound.identifier)
-
+          let cIndex = pCourseData['children'].indexOf(currData.identifier)
+          let pIndex = pCourseData['children'].indexOf(previousFound.identifier)
+          pCourseData['children'].splice(pIndex, 1)
+          pCourseData['children'].splice(cIndex, 0, previousFound.identifier)
         }
         console.log(hierarchy)
         //console.log(currData["children"])
@@ -4737,12 +4776,12 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       if (currentPosition === prevPosition) {
         if (identfs.includes(prevPosition)) {
           let parentData = hierarchy[this.courseData.identifier]
-          parentData["children"].push(prevPosition)
+          parentData['children'].push(prevPosition)
           if (currentFound.contentType === 'Resource') {
             let pCourseData = hierarchy[currentFound.parent]
             console.log(pCourseData)
-            let pIndex = pCourseData["children"].indexOf(currentFound.identifier)
-            pCourseData["children"].splice(pIndex, 1)
+            let pIndex = pCourseData['children'].indexOf(currentFound.identifier)
+            pCourseData['children'].splice(pIndex, 1)
           }
         }
       }
@@ -4760,7 +4799,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       },
     }
 
-    console.log(requestBodyV2, "data")
+    console.log(requestBodyV2, 'data')
     await this.editorService.updateContentV4(requestBodyV2).subscribe(() => {
       this.editorService.readcontentV3(this.contentService.parentContent).subscribe((data: any) => {
         this.loader.changeLoad.next(false)
@@ -4815,10 +4854,15 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       if (requestBody.request.content.category) {
         delete (requestBody as any).request.content.category
       }
-      const contenUpdateRes: any =
-        await this.editorService.updateContentV3(requestBody, currentContent).toPromise().catch(_error => { })
+      const contenUpdateRes: any = await this.editorService
+        .updateContentV3(requestBody, currentContent)
+        .toPromise()
+        .catch(_error => {})
       if (contenUpdateRes && contenUpdateRes.params && contenUpdateRes.params.status === 'successful') {
-        const hierarchyData = await this.editorService.readcontentV3(this.contentService.parentContent).toPromise().catch(_error => { })
+        const hierarchyData = await this.editorService
+          .readcontentV3(this.contentService.parentContent)
+          .toPromise()
+          .catch(_error => {})
         if (hierarchyData) {
           this.loader.changeLoad.next(true)
           this.contentService.resetOriginalMetaWithHierarchy(hierarchyData)
@@ -4832,11 +4876,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
 
   upload() {
     const formdata = new FormData()
-    formdata.append(
-      'content',
-      this.file as Blob,
-      (this.file as File).name.replace(/[^A-Za-z0-9_.]/g, ''),
-    )
+    formdata.append('content', this.file as Blob, (this.file as File).name.replace(/[^A-Za-z0-9_.]/g, ''))
     this.loader.changeLoad.next(true)
     this.uploadService
       .upload(
@@ -4853,13 +4893,14 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         undefined,
         // this.mimeType === 'application/html',
         this.mimeType === 'application/vnd.ekstep.html-archive',
-      ).pipe(
+      )
+      .pipe(
         tap(v => {
           this.canUpdate = false
           // const artifactUrl = v.result && v.result.artifactUrl ? v.result.artifactUrl : ''
           const artifactUrl = v && v.artifactUrl ? v.artifactUrl : ''
           // tslint:disable-next-line:no-console
-          console.log("this.mimeType", this.mimeType)
+          console.log('this.mimeType', this.mimeType)
           if (this.mimeType === 'video/mp4' || this.mimeType === 'application/pdf' || this.mimeType === 'audio/mpeg') {
             this.fileUploadForm.controls.artifactUrl.setValue(v ? this.generateUrl(artifactUrl) : '')
             this.fileUploadForm.controls.downloadUrl.setValue(v ? this.generateUrl(artifactUrl) : '')
@@ -4879,8 +4920,9 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
           this.fileUploadForm.controls.mimeType.setValue(this.mimeType)
           if (this.mimeType === 'application/vnd.ekstep.html-archive' && this.file && this.file.name.toLowerCase().endsWith('.zip')) {
             this.fileUploadForm.controls.isExternal.setValue(false)
-            this.fileUploadForm.controls['streamingUrl'].setValue(v ?
-              this.generateStreamUrl((this.fileUploadCondition.url) ? this.fileUploadCondition.url : '') : '')
+            this.fileUploadForm.controls['streamingUrl'].setValue(
+              v ? this.generateStreamUrl(this.fileUploadCondition.url ? this.fileUploadCondition.url : '') : '',
+            )
             this.fileUploadForm.controls['entryPoint'].setValue(this.entryPoint ? this.entryPoint : '')
             this.fileUploadForm.controls.duration.setValue(this.duration)
           }
@@ -4898,7 +4940,6 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
           this.canUpdate = true
         }),
         mergeMap(v => {
-
           if (this.mimeType === 'application/pdf') {
             this.profanityCheckAPICall(v.artifactUrl)
           }
@@ -4921,7 +4962,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
             this.courseData = data
           })
           this.loader.changeLoad.next(false)
-          console.log("uploadVideoUrl", this.uploadVideoUrl)
+          console.log('uploadVideoUrl', this.uploadVideoUrl)
         },
         () => {
           this.loader.changeLoad.next(false)
@@ -4937,9 +4978,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
       )
   }
   validateFile(file: File) {
-    const content = document.createElement(
-      this.mimeType === 'video/mp4' ? 'video' : 'audio',
-    )
+    const content = document.createElement(this.mimeType === 'video/mp4' ? 'video' : 'audio')
     content.preload = 'metadata'
     content.onloadedmetadata = () => {
       window.URL.revokeObjectURL(content.src)
@@ -4952,9 +4991,8 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
     return `${environment.azureHost}/${environment.azureBucket}/html/${this.currentContent}-snapshot/${fileName}`
   }
 
-
   profanityCheckAPICall(url: string) {
-    this.profanityService.startProfanity(this.currentContent, url, (this.file ? this.file.name : this.currentContent)).subscribe()
+    this.profanityService.startProfanity(this.currentContent, url, this.file ? this.file.name : this.currentContent).subscribe()
   }
 
   errorMessage() {
@@ -4973,18 +5011,12 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
     Object.keys(currentMeta).map(v => {
       if (
         v !== 'versionKey' &&
-        JSON.stringify(currentMeta[v as keyof NSContent.IContentMeta]) !==
-        JSON.stringify(originalMeta[v as keyof NSContent.IContentMeta])
+        JSON.stringify(currentMeta[v as keyof NSContent.IContentMeta]) !== JSON.stringify(originalMeta[v as keyof NSContent.IContentMeta])
       ) {
-        if (
-          currentMeta[v] ||
-          (this.initService.authConfig[v as keyof IFormMeta].type === 'boolean' &&
-            currentMeta[v] === false)
-        ) {
+        if (currentMeta[v] || (this.initService.authConfig[v as keyof IFormMeta].type === 'boolean' && currentMeta[v] === false)) {
           if (v !== 'duration') {
             meta[v] = currentMeta[v]
           }
-
         } else {
           if (v !== 'duration') {
             meta[v] = JSON.parse(
@@ -5014,7 +5046,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
   }
   /*PDF/audio/vedio functionality end*/
   takeActions(action: string, node: IContentTreeNode) {
-    console.log("action", action, node)
+    console.log('action', action, node)
     switch (action) {
       case 'editMeta':
       case 'editContent':
@@ -5029,7 +5061,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
   }
 
   delete(node: IContentTreeNode) {
-    console.log("node", node)
+    console.log('node', node)
     const dialogRef = this.dialog.open(ConfirmDialogComponent, {
       width: '420px',
       data: 'deleteTreeNode',
@@ -5054,17 +5086,16 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         }
         node.parent = parent
 
-
-        console.log("yes here", hierarchyData, node)
+        console.log('yes here', hierarchyData, node)
         Object.keys(hierarchyData).forEach(async (ele: any) => {
           if (ele === node.identifier) {
             this.storeService.deleteContentNode(node)
             delete (hierarchyData as any)[ele]
           }
           if (ele === node.parent) {
-            const index = hierarchyData[ele]["children"].indexOf(node.identifier)
+            const index = hierarchyData[ele]['children'].indexOf(node.identifier)
             if (index > -1) {
-              hierarchyData[ele]["children"].splice(index, 1)
+              hierarchyData[ele]['children'].splice(index, 1)
               const requestBodyV2: NSApiRequest.IContentUpdateV3 = {
                 request: {
                   data: {
@@ -5087,10 +5118,9 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
                   }
                   this.snackBar.openFromComponent(NotificationComponent, {
                     data: {
-                      type: Notify.SUCCESS
+                      type: Notify.SUCCESS,
                     },
                     duration: NOTIFICATION_TIME * 500,
-
                   })
                   this.loader.changeLoad.next(false)
                   this.clearForm()
@@ -5136,7 +5166,6 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
   }
   /*Assessment functionality start*/
   getassessment() {
-
     this.activeContentSubscription = this.contentService.changeActiveCont.subscribe(id => {
       this.allLanguages = this.initService.ordinals.subTitles
       this.loader.changeLoadState(true)
@@ -5156,8 +5185,10 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
           this.quizResolverSvc.getUpdatedData(v.contents[0].content.identifier).subscribe(newData => {
             const quizContent = this.contentService.getOriginalMeta(this.contentService.currentContent)
             if (quizContent.mimeType === 'application/json') {
-              const fileData = ((quizContent.artifactUrl || quizContent.downloadUrl) ?
-                this.quizResolverSvc.getJSON(this.generateUrl(quizContent.artifactUrl || quizContent.downloadUrl)) : of({} as any))
+              const fileData =
+                quizContent.artifactUrl || quizContent.downloadUrl
+                  ? this.quizResolverSvc.getJSON(this.generateUrl(quizContent.artifactUrl || quizContent.downloadUrl))
+                  : of({} as any)
               fileData.subscribe(jsonResponse => {
                 if (jsonResponse && Object.keys(jsonResponse).length > 1) {
                   if (v.contents && v.contents.length) {
@@ -5165,7 +5196,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
                       v.contents[0].data = jsonResponse
                       this.quizStoreSvc.assessmentDuration = jsonResponse.assessmentDuration
                       this.quizStoreSvc.passPercentage = jsonResponse.passPercentage
-                      this.assessmentDuration = (jsonResponse.assessmentDuration) / 60
+                      this.assessmentDuration = jsonResponse.assessmentDuration / 60
                       this.passPercentage = jsonResponse.passPercentage
                     }
                     this.allContents.push(v.contents[0].content)
@@ -5180,8 +5211,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
                           // need to arrange
                           this.canEditJson = this.quizResolverSvc.canEdit(quizContent)
                           this.resourceType = quizContent.categoryType || 'Assessment'
-                          this.questionsArr =
-                            this.quizStoreSvc.collectiveQuiz[id] || []
+                          this.questionsArr = this.quizStoreSvc.collectiveQuiz[id] || []
                           this.contentLoaded = true
                           this.questionsArr = this.quizStoreSvc.collectiveQuiz[id]
                           this.currentId = id
@@ -5194,8 +5224,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
                     this.canEditJson = this.quizResolverSvc.canEdit(quizContent)
                     this.resourceType = quizContent.categoryType || 'Assessment'
                     this.quizDuration = quizContent.duration || '300'
-                    this.questionsArr =
-                      this.quizStoreSvc.collectiveQuiz[id] || []
+                    this.questionsArr = this.quizStoreSvc.collectiveQuiz[id] || []
                     this.contentLoaded = true
                   }
                   if (!this.quizStoreSvc.collectiveQuiz[id]) {
@@ -5207,8 +5236,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
                   this.canEditJson = this.quizResolverSvc.canEdit(quizContent)
                   this.resourceType = quizContent.categoryType || 'Assessment'
                   this.quizDuration = quizContent.duration || '300'
-                  this.questionsArr =
-                    this.quizStoreSvc.collectiveQuiz[id] || []
+                  this.questionsArr = this.quizStoreSvc.collectiveQuiz[id] || []
                   this.contentLoaded = true
                   if (!this.quizStoreSvc.collectiveQuiz[id]) {
                     this.quizStoreSvc.collectiveQuiz[id] = []
@@ -5248,7 +5276,7 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
         type: 'editAssessment',
         index: index + 1,
         currentContent: this.currentContent,
-        data: data
+        data: data,
       },
     })
     dialogRefForPublish.componentInstance.onFormChange.subscribe((result: any) => {
@@ -5334,11 +5362,14 @@ export class ModuleCreationComponent implements OnInit, OnChanges, AfterViewInit
               gatingEnabled: this.isGating,
               instructions: this.topicDescription,
               thumbnail: this.thumbnail,
-              duration: this.timeToSeconds().toString()
+              duration: this.timeToSeconds().toString(),
             },
           },
         }
-        await this.editorService.updateNewContentV3(updateContentReq, this.currentCourseId).toPromise().catch((_error: any) => { })
+        await this.editorService
+          .updateNewContentV3(updateContentReq, this.currentCourseId)
+          .toPromise()
+          .catch((_error: any) => {})
         await this.editorService.readcontentV3(this.currentCourseId).subscribe(async (data: any) => {
           this.courseData = data
           this.loader.changeLoad.next(false)

--- a/project/ws/author/src/lib/routing/modules/editor/shared/components/edit-meta/edit-meta.component.html
+++ b/project/ws/author/src/lib/routing/modules/editor/shared/components/edit-meta/edit-meta.component.html
@@ -445,8 +445,7 @@
                   >Description is required</mat-error
                 >
                 <mat-error *ngIf="contentForm.controls.instructions.hasError('maxByteLength')" i18n>
-                  Description is too long ({{ instructionsByteLength }}/{{ maxInstructionsBytes }} bytes). Please shorten it or remove heavy
-                  formatting pasted from Word/Docs — over-long descriptions break content search indexing.
+                  Description is too long ({{ instructionsByteLength }}/{{ maxInstructionsBytes }} bytes). Please shorten it.
                 </mat-error>
               </div>
             </div>

--- a/project/ws/author/src/lib/routing/modules/editor/shared/components/edit-meta/edit-meta.component.html
+++ b/project/ws/author/src/lib/routing/modules/editor/shared/components/edit-meta/edit-meta.component.html
@@ -1,29 +1,25 @@
-<form [formGroup]="contentForm" *ngIf="!clickedBtnNext&&contentForm">
+<form [formGroup]="contentForm" *ngIf="!clickedBtnNext && contentForm">
   <!-- ── Course Settings Sidenav ─────────────────────────────────────────── -->
   <mat-sidenav class="em-sidenav" position="end" [fixedInViewport]="true" [(opened)]="sideNavBarOpened">
-
     <!-- Header -->
     <div class="em-sn-header">
       <div class="em-sn-header-inner">
         <span class="em-card-icon"><mat-icon>tune</mat-icon></span>
         <span class="em-sn-title" i18n>Course Settings</span>
       </div>
-      <button mat-icon-button class="em-sn-close" type="button"
-        (click)="sideNavBarOpened = false" aria-label="Close settings">
+      <button mat-icon-button class="em-sn-close" type="button" (click)="sideNavBarOpened = false" aria-label="Close settings">
         <mat-icon>close</mat-icon>
       </button>
     </div>
 
     <!-- Body -->
     <div class="em-sn-body">
-
       <!-- Display Settings -->
       <div class="em-sn-section">
         <p class="em-sn-section-label" i18n>Display Settings</p>
 
         <div [ngClass]="{ disable: checkCondition('complexityLevel', 'disabled') }">
-          <mat-form-field appearance="outline" class="em-field"
-            [ngClass]="{ 'mat-form-field-invalid': showError('complexityLevel') }">
+          <mat-form-field appearance="outline" class="em-field" [ngClass]="{ 'mat-form-field-invalid': showError('complexityLevel') }">
             <mat-label i18n>Proficiency Level</mat-label>
             <mat-select formControlName="complexityLevel" i18n-placeholder placeholder="--Select--">
               <mat-option *ngIf="!checkCondition('complexityLevel', 'required')" i18n [value]="null">None</mat-option>
@@ -37,8 +33,7 @@
         </div>
 
         <div [ngClass]="{ disable: checkCondition('visibility', 'disabled') }">
-          <mat-form-field appearance="outline" class="em-field"
-            [ngClass]="{ 'mat-form-field-invalid': showError('visibility') }">
+          <mat-form-field appearance="outline" class="em-field" [ngClass]="{ 'mat-form-field-invalid': showError('visibility') }">
             <mat-label i18n>Preview in Draft Mode</mat-label>
             <mat-select formControlName="visibility" i18n-placeholder placeholder="--Select--">
               <mat-option [value]="'Private'" i18n>Don't Allow</mat-option>
@@ -46,9 +41,12 @@
             </mat-select>
             <mat-hint>
               <span i18n>Anyone with this URL can see the content</span>
-              <mat-icon *ngIf="contentForm.controls.visibility.value === 'Public'"
+              <mat-icon
+                *ngIf="contentForm.controls.visibility.value === 'Public'"
                 matTooltip="Click to copy the private url"
-                class="em-sn-copy-icon" (click)="copyData('previewUrl')">file_copy
+                class="em-sn-copy-icon"
+                (click)="copyData('previewUrl')"
+                >file_copy
               </mat-icon>
             </mat-hint>
             <mat-error *ngIf="showError('visibility')" i18n>This field is mandatory</mat-error>
@@ -61,22 +59,29 @@
         <p class="em-sn-section-label" i18n>Audience & Targeting</p>
 
         <div [ngClass]="{ disable: checkCondition('audience', 'disabled') }">
-          <mat-form-field appearance="outline" class="em-field"
-            [ngClass]="{ 'mat-form-field-invalid': showError('audience') }">
+          <mat-form-field appearance="outline" class="em-field" [ngClass]="{ 'mat-form-field-invalid': showError('audience') }">
             <mat-label i18n>Audience</mat-label>
             <mat-chip-grid #audienceChipList i18n-aria-label aria-label="Audience selection">
-              <mat-chip-row *ngFor="let job of contentForm.controls.audience.value; trackBy: trackByIndex"
-                (removed)="removeFromFormControl(job, 'audience')">
+              <mat-chip-row
+                *ngFor="let job of contentForm.controls.audience.value; trackBy: trackByIndex"
+                (removed)="removeFromFormControl(job, 'audience')"
+              >
                 {{ job }}
                 <mat-icon matChipRemove *ngIf="removable">cancel</mat-icon>
               </mat-chip-row>
-              <input i18n-placeholder placeholder="Add audience..." #audienceView
-                [formControl]="audienceCtrl" [matChipInputFor]="audienceChipList"
-                [matAutocomplete]="audienceAuto" [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-                [matChipInputAddOnBlur]="false" (matChipInputTokenEnd)="removeField($event)" />
+              <input
+                i18n-placeholder
+                placeholder="Add audience..."
+                #audienceView
+                [formControl]="audienceCtrl"
+                [matChipInputFor]="audienceChipList"
+                [matAutocomplete]="audienceAuto"
+                [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
+                [matChipInputAddOnBlur]="false"
+                (matChipInputTokenEnd)="removeField($event)"
+              />
             </mat-chip-grid>
-            <mat-autocomplete #audienceAuto="matAutocomplete"
-              (optionSelected)="addToFormControl($event, 'audience')">
+            <mat-autocomplete #audienceAuto="matAutocomplete" (optionSelected)="addToFormControl($event, 'audience')">
               <mat-option *ngIf="!checkCondition('audience', 'required')" i18n [value]="null">None</mat-option>
               <mat-option *ngFor="let job of audienceList; trackBy: trackByIndex" [value]="job">{{ job }}</mat-option>
             </mat-autocomplete>
@@ -84,24 +89,30 @@
           </mat-form-field>
         </div>
 
-        <div *ngIf="checkCondition('jobProfile', 'show')"
-          [ngClass]="{ disable: checkCondition('jobProfile', 'disabled') }">
-          <mat-form-field appearance="outline" class="em-field"
-            [ngClass]="{ 'mat-form-field-invalid': showError('jobProfile') }">
+        <div *ngIf="checkCondition('jobProfile', 'show')" [ngClass]="{ disable: checkCondition('jobProfile', 'disabled') }">
+          <mat-form-field appearance="outline" class="em-field" [ngClass]="{ 'mat-form-field-invalid': showError('jobProfile') }">
             <mat-label i18n>Job Profiles</mat-label>
             <mat-chip-grid #jobProfileChipList i18n-aria-label aria-label="Job profile selection">
-              <mat-chip-row *ngFor="let job of contentForm.controls.jobProfile.value; trackBy: trackByIndex"
-                (removed)="removeFromFormControl(job, 'jobProfile')">
+              <mat-chip-row
+                *ngFor="let job of contentForm.controls.jobProfile.value; trackBy: trackByIndex"
+                (removed)="removeFromFormControl(job, 'jobProfile')"
+              >
                 {{ job }}
                 <mat-icon matChipRemove *ngIf="removable">cancel</mat-icon>
               </mat-chip-row>
-              <input i18n-placeholder placeholder="Add job profile..." #jobProfileView
-                [formControl]="jobProfileCtrl" [matChipInputFor]="jobProfileChipList"
-                [matAutocomplete]="jobProfileAuto" [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-                [matChipInputAddOnBlur]="false" (matChipInputTokenEnd)="removeField($event)" />
+              <input
+                i18n-placeholder
+                placeholder="Add job profile..."
+                #jobProfileView
+                [formControl]="jobProfileCtrl"
+                [matChipInputFor]="jobProfileChipList"
+                [matAutocomplete]="jobProfileAuto"
+                [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
+                [matChipInputAddOnBlur]="false"
+                (matChipInputTokenEnd)="removeField($event)"
+              />
             </mat-chip-grid>
-            <mat-autocomplete #jobProfileAuto="matAutocomplete"
-              (optionSelected)="addToFormControl($event, 'jobProfile')">
+            <mat-autocomplete #jobProfileAuto="matAutocomplete" (optionSelected)="addToFormControl($event, 'jobProfile')">
               <mat-option *ngIf="!checkCondition('jobProfile', 'required')" i18n [value]="null">None</mat-option>
               <mat-option *ngFor="let job of jobProfileList; trackBy: trackByIndex" [value]="job">{{ job }}</mat-option>
             </mat-autocomplete>
@@ -109,22 +120,25 @@
           </mat-form-field>
         </div>
 
-        <div *ngIf="checkCondition('skills', 'show')"
-          [ngClass]="{ disable: checkCondition('skills', 'disabled') }">
-          <mat-form-field appearance="outline" class="em-field"
-            [ngClass]="{ 'mat-form-field-invalid': showError('skills') }">
+        <div *ngIf="checkCondition('skills', 'show')" [ngClass]="{ disable: checkCondition('skills', 'disabled') }">
+          <mat-form-field appearance="outline" class="em-field" [ngClass]="{ 'mat-form-field-invalid': showError('skills') }">
             <mat-label>Skills</mat-label>
             <mat-chip-grid #skills aria-label="Keyword selection">
               <mat-chip-row *ngFor="let key of contentForm.controls.skills.value; trackBy: trackByIndex" (removed)="removeSkill(key)">
                 {{ key }}
                 <mat-icon matChipRemove *ngIf="removable">cancel</mat-icon>
               </mat-chip-row>
-              <input i18n-placeholder formControlName="skills" placeholder="Add skills..." #skillsView
-                [matChipInputFor]="skills" [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-                [matChipInputAddOnBlur]="true" />
+              <input
+                i18n-placeholder
+                formControlName="skills"
+                placeholder="Add skills..."
+                #skillsView
+                [matChipInputFor]="skills"
+                [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
+                [matChipInputAddOnBlur]="true"
+              />
             </mat-chip-grid>
-            <mat-select [compareWith]="compareSkillFn" formControlName="skills"
-              [required]="checkCondition('skills', 'required')" multiple>
+            <mat-select [compareWith]="compareSkillFn" formControlName="skills" [required]="checkCondition('skills', 'required')" multiple>
               <mat-option *ngFor="let skill of ordinals.skills; trackBy: trackByIndex" [value]="skill">{{ skill.name }}</mat-option>
             </mat-select>
             <mat-error *ngIf="showError('skills')" i18n>Skills is mandatory</mat-error>
@@ -136,27 +150,39 @@
       <div class="em-sn-section" [ngClass]="{ disable: checkCondition('keywords', 'disabled') }">
         <p class="em-sn-section-label">
           <span i18n>Keywords</span>
-          <mat-icon class="em-sn-copy-icon"
+          <mat-icon
+            class="em-sn-copy-icon"
             *ngIf="contentForm.controls.keywords.value && contentForm.controls.keywords.value.length"
-            (click)="copyData('keyword')">file_copy
+            (click)="copyData('keyword')"
+            >file_copy
           </mat-icon>
         </p>
-        <mat-form-field class="em-field" appearance="outline"
-          [ngClass]="{ 'mat-form-field-invalid': showError('keywords') }">
+        <mat-form-field class="em-field" appearance="outline" [ngClass]="{ 'mat-form-field-invalid': showError('keywords') }">
           <mat-label [ngClass]="{ required: checkCondition('keywords', 'required') }" i18n>Keywords</mat-label>
           <mat-chip-grid #keywords aria-label="Keyword selection">
             <mat-chip-row *ngFor="let key of contentForm.controls.keywords.value; trackBy: trackByIndex" (removed)="removeKeyword(key)">
               {{ key }}
               <mat-icon matChipRemove *ngIf="removable">cancel</mat-icon>
             </mat-chip-row>
-            <input i18n-placeholder [formControl]="keywordsCtrl" [matAutocomplete]="auto"
-              placeholder="Type and press Enter..." #keywordsView [matChipInputFor]="keywords"
-              [matChipInputSeparatorKeyCodes]="separatorKeysCodes" [matChipInputAddOnBlur]="false"
-              (matChipInputTokenEnd)="addKeyword($event)" #keywordsSearch />
+            <input
+              i18n-placeholder
+              [formControl]="keywordsCtrl"
+              [matAutocomplete]="auto"
+              placeholder="Type and press Enter..."
+              #keywordsView
+              [matChipInputFor]="keywords"
+              [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
+              [matChipInputAddOnBlur]="false"
+              (matChipInputTokenEnd)="addKeyword($event)"
+              #keywordsSearch
+            />
           </mat-chip-grid>
         </mat-form-field>
-        <mat-autocomplete #auto="matAutocomplete" autoActiveFirstOption
-          (optionSelected)="optionSelected($event.option.value); keywordsView.value = ''">
+        <mat-autocomplete
+          #auto="matAutocomplete"
+          autoActiveFirstOption
+          (optionSelected)="optionSelected($event.option.value); keywordsView.value = ''"
+        >
           <mat-option *ngIf="keywordsSearch.value" [value]="keywordsSearch.value">{{ keywordsSearch.value }}</mat-option>
           <mat-option *ngFor="let option of filteredOptions$ | async; trackBy: trackByIndex" [value]="option">{{ option }}</mat-option>
         </mat-autocomplete>
@@ -167,25 +193,33 @@
         <p class="em-sn-section-label" i18n>Stakeholders</p>
 
         <div [ngClass]="{ disable: checkCondition('trackContacts', 'disabled') }">
-          <mat-form-field appearance="outline" class="em-field"
-            [ngClass]="{ 'mat-form-field-invalid': showError('trackContacts') }">
+          <mat-form-field appearance="outline" class="em-field" [ngClass]="{ 'mat-form-field-invalid': showError('trackContacts') }">
             <mat-label [ngClass]="{ required: checkCondition('trackContacts', 'required') }" i18n>Reviewers</mat-label>
             <mat-chip-grid #reviewerChipList i18n-aria-label aria-label="Reviewer selection">
-              <mat-chip-row *ngFor="let author of contentForm.controls.trackContacts.value; trackBy: trackByIndex"
-                (removed)="removeEmployee(author, 'trackContacts')">
+              <mat-chip-row
+                *ngFor="let author of contentForm.controls.trackContacts.value; trackBy: trackByIndex"
+                (removed)="removeEmployee(author, 'trackContacts')"
+              >
                 {{ author.name }}
                 <mat-icon matChipRemove *ngIf="removable">cancel</mat-icon>
               </mat-chip-row>
-              <input i18n-placeholder placeholder="Search by email..." #trackContactsView
-                [formControl]="trackContactsCtrl" [matChipInputFor]="reviewerChipList"
-                [matAutocomplete]="reivewerAuto" [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-                [matChipInputAddOnBlur]="false" (matChipInputTokenEnd)="removeField($event)" />
+              <input
+                i18n-placeholder
+                placeholder="Search by email..."
+                #trackContactsView
+                [formControl]="trackContactsCtrl"
+                [matChipInputFor]="reviewerChipList"
+                [matAutocomplete]="reivewerAuto"
+                [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
+                [matChipInputAddOnBlur]="false"
+                (matChipInputTokenEnd)="removeField($event)"
+              />
             </mat-chip-grid>
-            <mat-autocomplete #reivewerAuto="matAutocomplete"
-              (optionSelected)="addEmployee($event, 'trackContacts')">
+            <mat-autocomplete #reivewerAuto="matAutocomplete" (optionSelected)="addEmployee($event, 'trackContacts')">
               <mat-option *ngIf="fetchTagsStatus === 'fetching'" i18n>Fetching users...</mat-option>
               <mat-option *ngIf="fetchTagsStatus === 'done' && !employeeList.length" i18n>
-                No user found. Please check the value entered.</mat-option>
+                No user found. Please check the value entered.</mat-option
+              >
               <mat-option *ngFor="let author of employeeList; trackBy: trackByIndex" [value]="author">
                 {{ author.displayName }} | {{ author.mail }}
               </mat-option>
@@ -195,25 +229,33 @@
         </div>
 
         <div [ngClass]="{ disable: checkCondition('publisherDetails', 'disabled') }">
-          <mat-form-field appearance="outline" class="em-field"
-            [ngClass]="{ 'mat-form-field-invalid': showError('publisherDetails') }">
+          <mat-form-field appearance="outline" class="em-field" [ngClass]="{ 'mat-form-field-invalid': showError('publisherDetails') }">
             <mat-label [ngClass]="{ required: checkCondition('publisherDetails', 'required') }" i18n>Publishers</mat-label>
             <mat-chip-grid #publisherChipList aria-label="Publisher selection">
-              <mat-chip-row *ngFor="let author of contentForm.controls.publisherDetails.value; trackBy: trackByIndex"
-                (removed)="removeEmployee(author, 'publisherDetails')">
+              <mat-chip-row
+                *ngFor="let author of contentForm.controls.publisherDetails.value; trackBy: trackByIndex"
+                (removed)="removeEmployee(author, 'publisherDetails')"
+              >
                 {{ author.name }}
                 <mat-icon matChipRemove *ngIf="removable">cancel</mat-icon>
               </mat-chip-row>
-              <input i18n-placeholder placeholder="Search by email..." #publisherDetailsView
-                [formControl]="publisherDetailsCtrl" [matChipInputFor]="publisherChipList"
-                [matAutocomplete]="publisherAuto" [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-                [matChipInputAddOnBlur]="false" (matChipInputTokenEnd)="removeField($event)" />
+              <input
+                i18n-placeholder
+                placeholder="Search by email..."
+                #publisherDetailsView
+                [formControl]="publisherDetailsCtrl"
+                [matChipInputFor]="publisherChipList"
+                [matAutocomplete]="publisherAuto"
+                [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
+                [matChipInputAddOnBlur]="false"
+                (matChipInputTokenEnd)="removeField($event)"
+              />
             </mat-chip-grid>
-            <mat-autocomplete #publisherAuto="matAutocomplete"
-              (optionSelected)="addEmployee($event, 'publisherDetails')">
+            <mat-autocomplete #publisherAuto="matAutocomplete" (optionSelected)="addEmployee($event, 'publisherDetails')">
               <mat-option *ngIf="fetchTagsStatus === 'fetching'" i18n>Fetching users...</mat-option>
               <mat-option *ngIf="fetchTagsStatus === 'done' && !employeeList.length" i18n>
-                No user found. Please check the value entered.</mat-option>
+                No user found. Please check the value entered.</mat-option
+              >
               <mat-option *ngFor="let author of employeeList; trackBy: trackByIndex" [value]="author">
                 {{ author.displayName }} | {{ author.mail }}
               </mat-option>
@@ -223,25 +265,33 @@
         </div>
 
         <div [ngClass]="{ disable: checkCondition('creatorContacts', 'disabled') }">
-          <mat-form-field appearance="outline" class="em-field"
-            [ngClass]="{ 'mat-form-field-invalid': showError('creatorContacts') }">
+          <mat-form-field appearance="outline" class="em-field" [ngClass]="{ 'mat-form-field-invalid': showError('creatorContacts') }">
             <mat-label i18n>Curators / Contacts</mat-label>
             <mat-chip-grid #creatorChipList aria-label="Creator selection">
-              <mat-chip-row *ngFor="let author of contentForm.controls.creatorContacts.value; trackBy: trackByIndex"
-                (removed)="removeEmployee(author, 'creatorContacts')">
+              <mat-chip-row
+                *ngFor="let author of contentForm.controls.creatorContacts.value; trackBy: trackByIndex"
+                (removed)="removeEmployee(author, 'creatorContacts')"
+              >
                 {{ author.name }}
                 <mat-icon matChipRemove *ngIf="removable">cancel</mat-icon>
               </mat-chip-row>
-              <input i18n-placeholder placeholder="Search by email..." #creatorContactsView
-                [formControl]="creatorContactsCtrl" [matChipInputFor]="creatorChipList"
-                [matAutocomplete]="creatorAuto" [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-                [matChipInputAddOnBlur]="false" (matChipInputTokenEnd)="removeField($event)" />
+              <input
+                i18n-placeholder
+                placeholder="Search by email..."
+                #creatorContactsView
+                [formControl]="creatorContactsCtrl"
+                [matChipInputFor]="creatorChipList"
+                [matAutocomplete]="creatorAuto"
+                [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
+                [matChipInputAddOnBlur]="false"
+                (matChipInputTokenEnd)="removeField($event)"
+              />
             </mat-chip-grid>
-            <mat-autocomplete #creatorAuto="matAutocomplete"
-              (optionSelected)="addEmployee($event, 'creatorContacts')">
+            <mat-autocomplete #creatorAuto="matAutocomplete" (optionSelected)="addEmployee($event, 'creatorContacts')">
               <mat-option *ngIf="fetchTagsStatus === 'fetching'" i18n>Fetching users...</mat-option>
               <mat-option *ngIf="fetchTagsStatus === 'done' && !employeeList.length" i18n>
-                No user found. Please check the value entered.</mat-option>
+                No user found. Please check the value entered.</mat-option
+              >
               <mat-option *ngFor="let author of employeeList; trackBy: trackByIndex" [value]="author">
                 {{ author.displayName }} | {{ author.mail }}
               </mat-option>
@@ -251,25 +301,33 @@
         </div>
 
         <div [ngClass]="{ disable: checkCondition('creatorDetails', 'disabled') }">
-          <mat-form-field appearance="outline" class="em-field"
-            [ngClass]="{ 'mat-form-field-invalid': showError('creatorDetails') }">
+          <mat-form-field appearance="outline" class="em-field" [ngClass]="{ 'mat-form-field-invalid': showError('creatorDetails') }">
             <mat-label i18n>Authors</mat-label>
             <mat-chip-grid #creatorDetailsChipList aria-label="Original Author selection">
-              <mat-chip-row *ngFor="let author of contentForm.controls.creatorDetails.value; trackBy: trackByIndex"
-                (removed)="removeCreatorDetails(author)">
+              <mat-chip-row
+                *ngFor="let author of contentForm.controls.creatorDetails.value; trackBy: trackByIndex"
+                (removed)="removeCreatorDetails(author)"
+              >
                 {{ author.name }}
                 <mat-icon matChipRemove *ngIf="removable">cancel</mat-icon>
               </mat-chip-row>
-              <input i18n-placeholder placeholder="Enter name..." #creatorDetailsView
-                [formControl]="creatorDetailsCtrl" [matChipInputFor]="creatorDetailsChipList"
-                [matAutocomplete]="originalAuthorsAuto" [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-                [matChipInputAddOnBlur]="false" (matChipInputTokenEnd)="addCreatorDetails($event)" />
+              <input
+                i18n-placeholder
+                placeholder="Enter name..."
+                #creatorDetailsView
+                [formControl]="creatorDetailsCtrl"
+                [matChipInputFor]="creatorDetailsChipList"
+                [matAutocomplete]="originalAuthorsAuto"
+                [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
+                [matChipInputAddOnBlur]="false"
+                (matChipInputTokenEnd)="addCreatorDetails($event)"
+              />
             </mat-chip-grid>
-            <mat-autocomplete #originalAuthorsAuto="matAutocomplete"
-              (optionSelected)="addEmployee($event, 'creatorDetails')">
+            <mat-autocomplete #originalAuthorsAuto="matAutocomplete" (optionSelected)="addEmployee($event, 'creatorDetails')">
               <mat-option *ngIf="fetchTagsStatus === 'fetching'" i18n>Fetching users...</mat-option>
               <mat-option *ngIf="fetchTagsStatus === 'done' && !employeeList.length" i18n>
-                No user found. Please check the value entered.</mat-option>
+                No user found. Please check the value entered.</mat-option
+              >
               <mat-option *ngFor="let author of employeeList; trackBy: trackByIndex" [value]="author">
                 {{ author.displayName }} | {{ author.mail }}
               </mat-option>
@@ -285,8 +343,7 @@
       <button mat-stroked-button class="em-btn-draft" type="button" (click)="sideNavBarOpened = false">
         <span i18n>Cancel</span>
       </button>
-      <button mat-flat-button class="em-btn-next" type="button"
-        (click)="data.emit('save'); isSubmitPressed = true">
+      <button mat-flat-button class="em-btn-next" type="button" (click)="data.emit('save'); isSubmitPressed = true">
         <span i18n>Save Settings</span>
       </button>
     </div>
@@ -294,170 +351,203 @@
 
   <!-- ── Main Content ────────────────────────────────────────────────────── -->
   <div id="edit-meta" [ngClass]="{ disable: !isEditEnabled }">
-  <div class="em-page">
+    <div class="em-page">
+      <!-- ── 2-column page grid ── -->
+      <div class="em-grid">
+        <!-- ══ LEFT COLUMN ════════════════════════════════════════════════ -->
+        <div class="em-col-left">
+          <!-- Card: Basic Information -->
+          <div class="em-card">
+            <div class="em-card-header">
+              <span class="em-card-icon"><mat-icon>edit_note</mat-icon></span>
+              <div>
+                <h3 class="em-card-title" i18n>Basic Information</h3>
+                <p class="em-card-sub" i18n>Core details learners will see</p>
+              </div>
+            </div>
+            <div class="em-card-body">
+              <ng-container *ngIf="metaLoaded">
+                <mat-form-field appearance="outline" class="em-field" [ngClass]="{ 'mat-form-field-invalid': showError('name') }">
+                  <mat-label i18n>Course Name <span class="em-req">*</span></mat-label>
+                  <input
+                    matInput
+                    trim="blur"
+                    formControlName="name"
+                    #name
+                    maxlength="500"
+                    (keyup)="setPurposeValue(name.value)"
+                    i18n-placeholder
+                    placeholder="e.g., Advanced Infection Control Practices"
+                  />
+                  <mat-hint>{{ name.value.length }} / 500 <span i18n>characters</span></mat-hint>
+                  <mat-error i18n>Course name is required</mat-error>
+                </mat-form-field>
 
+                <mat-form-field appearance="outline" class="em-field" [ngClass]="{ 'mat-form-field-invalid': showError('subTitle') }">
+                  <mat-label i18n>Subtitle <span class="em-req">*</span></mat-label>
+                  <input
+                    matInput
+                    trim="blur"
+                    formControlName="subTitle"
+                    #subTitle
+                    maxlength="500"
+                    (keyup)="setPurposeValue(subTitle.value)"
+                    [required]="checkCondition('subTitle', 'required') ? true : null"
+                    i18n-placeholder
+                    placeholder="Short summary displayed to learners"
+                  />
+                  <mat-hint>{{ subTitle.value.length }} / 500 <span i18n>characters</span></mat-hint>
+                  <mat-error i18n>Subtitle is required</mat-error>
+                </mat-form-field>
 
-    <!-- ── 2-column page grid ── -->
-    <div class="em-grid">
-
-      <!-- ══ LEFT COLUMN ════════════════════════════════════════════════ -->
-      <div class="em-col-left">
-
-        <!-- Card: Basic Information -->
-        <div class="em-card">
-          <div class="em-card-header">
-            <span class="em-card-icon"><mat-icon>edit_note</mat-icon></span>
-            <div>
-              <h3 class="em-card-title" i18n>Basic Information</h3>
-              <p class="em-card-sub" i18n>Core details learners will see</p>
+                <mat-form-field
+                  appearance="outline"
+                  class="em-field"
+                  hideRequiredMarker
+                  [ngClass]="{ 'mat-form-field-invalid': showError('lang') }"
+                >
+                  <mat-label i18n>Course Language <span class="em-req">*</span></mat-label>
+                  <mat-select formControlName="lang">
+                    <mat-option *ngFor="let lang of languageList; trackBy: trackByIndex" [value]="lang.value">{{ lang.name }}</mat-option>
+                  </mat-select>
+                  <mat-hint i18n>Primary language of the course content</mat-hint>
+                  <mat-error i18n>Language is required</mat-error>
+                </mat-form-field>
+              </ng-container>
             </div>
           </div>
-          <div class="em-card-body">
-            <ng-container *ngIf="metaLoaded">
-            <mat-form-field appearance="outline" class="em-field"
-              [ngClass]="{ 'mat-form-field-invalid': showError('name') }">
-              <mat-label i18n>Course Name <span class="em-req">*</span></mat-label>
-              <input matInput trim="blur" formControlName="name" #name maxlength="500"
-                (keyup)="setPurposeValue(name.value)"
-                i18n-placeholder placeholder="e.g., Advanced Infection Control Practices" />
-              <mat-hint>{{ name.value.length }} / 500 <span i18n>characters</span></mat-hint>
-              <mat-error i18n>Course name is required</mat-error>
-            </mat-form-field>
 
-            <mat-form-field appearance="outline" class="em-field"
-              [ngClass]="{ 'mat-form-field-invalid': showError('subTitle') }">
-              <mat-label i18n>Subtitle <span class="em-req">*</span></mat-label>
-              <input matInput trim="blur" formControlName="subTitle" #subTitle maxlength="500"
-                (keyup)="setPurposeValue(subTitle.value)"
-                [required]="checkCondition('subTitle', 'required') ? true : null"
-                i18n-placeholder placeholder="Short summary displayed to learners" />
-              <mat-hint>{{ subTitle.value.length }} / 500 <span i18n>characters</span></mat-hint>
-              <mat-error i18n>Subtitle is required</mat-error>
-            </mat-form-field>
-
-            <mat-form-field appearance="outline" class="em-field" hideRequiredMarker
-              [ngClass]="{ 'mat-form-field-invalid': showError('lang') }">
-              <mat-label i18n>Course Language <span class="em-req">*</span></mat-label>
-              <mat-select formControlName="lang">
-                <mat-option *ngFor="let lang of languageList; trackBy: trackByIndex" [value]="lang.value">{{ lang.name }}</mat-option>
-              </mat-select>
-              <mat-hint i18n>Primary language of the course content</mat-hint>
-              <mat-error i18n>Language is required</mat-error>
-            </mat-form-field>
-            </ng-container>
-          </div>
-        </div>
-
-        <!-- Card: Course Description -->
-        <div class="em-card" [ngClass]="{ disable: checkCondition('instructions', 'disabled') }">
-          <div class="em-card-header">
-            <span class="em-card-icon"><mat-icon>subject</mat-icon></span>
-            <div>
-              <h3 class="em-card-title" i18n>Course Description</h3>
-              <p class="em-card-sub" i18n>Objectives, audience and key learning outcomes</p>
+          <!-- Card: Course Description -->
+          <div class="em-card" [ngClass]="{ disable: checkCondition('instructions', 'disabled') }">
+            <div class="em-card-header">
+              <span class="em-card-icon"><mat-icon>subject</mat-icon></span>
+              <div>
+                <h3 class="em-card-title" i18n>Course Description</h3>
+                <p class="em-card-sub" i18n>Objectives, audience and key learning outcomes</p>
+              </div>
             </div>
-          </div>
-          <div class="em-card-body">
-            <div *ngIf="contentForm && contentForm.controls"
-              [ngClass]="{ 'em-editor-error': showError('instructions') }">
-              <ws-auth-plain-ckeditor [editCoursePage]="'yes'" [editMeta]="editMeta" [location]="location"
-                [id]="contentMeta.identifier" [content]="contentForm.controls.instructions.value || ''"
-                (value)="updateContentService('instructions', $event)">
-              </ws-auth-plain-ckeditor>
-              <p class="em-editor-hint" i18n>Describe your course in 1–4 paragraphs</p>
-              <mat-error *ngIf="showError('instructions')" i18n>Description is required</mat-error>
-            </div>
-          </div>
-        </div>
-
-      </div><!-- /em-col-left -->
-
-      <!-- ══ RIGHT COLUMN ═══════════════════════════════════════════════ -->
-      <div class="em-col-right">
-
-        <!-- Card: Thumbnail -->
-        <div class="em-card" [ngClass]="{ disable: checkCondition('appIcon', 'disabled') }">
-          <div class="em-card-header">
-            <span class="em-card-icon"><mat-icon>image</mat-icon></span>
-            <div>
-              <h3 class="em-card-title" i18n>Course Thumbnail <span class="em-req">*</span></h3>
-              <p class="em-card-sub" i18n>760 × 400 px · JPG or PNG · max 1 MB</p>
-            </div>
-          </div>
-          <div class="em-card-body">
-            <ng-container *ngIf="metaLoaded">
-            <!-- Preview after upload -->
-            <div *ngIf="contentForm.controls.appIcon.value" class="em-thumb-preview">
-              <img [src]="contentForm.controls.appIcon.value" alt="Thumbnail preview"
-                class="em-thumb-img" (error)="changeToDefaultImg($event)" />
-              <button mat-stroked-button class="em-thumb-replace" type="button"
-                (click)="uploadThumbnail.click()">
-                <mat-icon>swap_horiz</mat-icon> <span i18n>Replace Image</span>
-              </button>
-            </div>
-
-            <!-- Drop zone (no image) -->
-            <div *ngIf="!contentForm.controls.appIcon.value" class="em-dropzone"
-              (click)="uploadThumbnail.click()"
-              (dragover)="$event.preventDefault()"
-              (drop)="$event.preventDefault(); uploadAppIcon($event.dataTransfer.files[0])">
-              <mat-icon class="em-dz-icon">cloud_upload</mat-icon>
-              <p class="em-dz-title" i18n>Drag & drop or <span class="em-dz-link">browse</span></p>
-              <p class="em-dz-meta" i18n>JPG, PNG · 760 × 400 px · max 1 MB</p>
-            </div>
-
-            <input type="file" #uploadThumbnail
-              (change)="uploadAppIcon($event.target.files[0]); uploadThumbnail.value = null"
-              style="display:none" [accept]="imageTypes.toString()" />
-            </ng-container>
-          </div>
-        </div>
-
-        <!-- Card: Competencies -->
-        <div class="em-card">
-          <div class="em-card-header">
-            <span class="em-card-icon"><mat-icon>school</mat-icon></span>
-            <div>
-              <h3 class="em-card-title" i18n>Competencies</h3>
-              <p class="em-card-sub" i18n>Map required skills to this course</p>
-            </div>
-            <button mat-flat-button class="em-add-comp-btn" (click)="addCompetency()" type="button">
-              <mat-icon>add</mat-icon> <span i18n>Add</span>
-            </button>
-          </div>
-          <div class="em-card-body em-comp-body">
-
-            <!-- Empty state -->
-            <div *ngIf="!addedCompetency || addedCompetency?.length === 0" class="em-comp-empty">
-              <mat-icon class="em-comp-empty-icon">radar</mat-icon>
-              <p class="em-comp-empty-title" i18n>No competencies added yet</p>
-              <p class="em-comp-empty-sub" i18n>Add at least one competency before publishing</p>
-              <button mat-stroked-button class="em-comp-cta" (click)="addCompetency()" type="button">
-                <mat-icon>add_circle_outline</mat-icon> <span i18n>Add Competency</span>
-              </button>
-            </div>
-
-            <!-- Competency cards -->
-            <div *ngIf="addedCompetency?.length > 0" class="em-comp-list">
-              <div *ngFor="let comp of addedCompetency; trackBy: trackByIndex" class="em-comp-chip">
-                <div class="em-comp-info">
-                  <span class="em-comp-code">{{ comp.Code }}</span>
-                  <span class="em-comp-name">{{ comp.competencyName }}</span>
-                  <span *ngIf="comp.level" class="em-comp-level" i18n>Level {{ comp.level }}</span>
-                </div>
-                <button class="em-comp-del" type="button"
-                  (click)="deleteCompetancy(comp)" aria-label="Remove">
-                  <mat-icon>close</mat-icon>
-                </button>
+            <div class="em-card-body">
+              <div *ngIf="contentForm && contentForm.controls" [ngClass]="{ 'em-editor-error': showError('instructions') }">
+                <ws-auth-plain-ckeditor
+                  [editCoursePage]="'yes'"
+                  [editMeta]="editMeta"
+                  [location]="location"
+                  [id]="contentMeta.identifier"
+                  [content]="contentForm.controls.instructions.value || ''"
+                  (value)="updateContentService('instructions', $event)"
+                >
+                </ws-auth-plain-ckeditor>
+                <p class="em-editor-hint" i18n>Describe your course in 1–4 paragraphs</p>
+                <p class="em-editor-hint" [style.color]="instructionsByteLength > maxInstructionsBytes ? '#d9534f' : '#808080'">
+                  {{ instructionsByteLength }} / {{ maxInstructionsBytes }} bytes
+                </p>
+                <mat-error *ngIf="showError('instructions') && contentForm.controls.instructions.hasError('required')" i18n
+                  >Description is required</mat-error
+                >
+                <mat-error *ngIf="contentForm.controls.instructions.hasError('maxByteLength')" i18n>
+                  Description is too long ({{ instructionsByteLength }}/{{ maxInstructionsBytes }} bytes). Please shorten it or remove heavy
+                  formatting pasted from Word/Docs — over-long descriptions break content search indexing.
+                </mat-error>
               </div>
             </div>
           </div>
         </div>
+        <!-- /em-col-left -->
 
-      </div><!-- /em-col-right -->
-    </div><!-- /em-grid -->
+        <!-- ══ RIGHT COLUMN ═══════════════════════════════════════════════ -->
+        <div class="em-col-right">
+          <!-- Card: Thumbnail -->
+          <div class="em-card" [ngClass]="{ disable: checkCondition('appIcon', 'disabled') }">
+            <div class="em-card-header">
+              <span class="em-card-icon"><mat-icon>image</mat-icon></span>
+              <div>
+                <h3 class="em-card-title" i18n>Course Thumbnail <span class="em-req">*</span></h3>
+                <p class="em-card-sub" i18n>760 × 400 px · JPG or PNG · max 1 MB</p>
+              </div>
+            </div>
+            <div class="em-card-body">
+              <ng-container *ngIf="metaLoaded">
+                <!-- Preview after upload -->
+                <div *ngIf="contentForm.controls.appIcon.value" class="em-thumb-preview">
+                  <img
+                    [src]="contentForm.controls.appIcon.value"
+                    alt="Thumbnail preview"
+                    class="em-thumb-img"
+                    (error)="changeToDefaultImg($event)"
+                  />
+                  <button mat-stroked-button class="em-thumb-replace" type="button" (click)="uploadThumbnail.click()">
+                    <mat-icon>swap_horiz</mat-icon> <span i18n>Replace Image</span>
+                  </button>
+                </div>
 
+                <!-- Drop zone (no image) -->
+                <div
+                  *ngIf="!contentForm.controls.appIcon.value"
+                  class="em-dropzone"
+                  (click)="uploadThumbnail.click()"
+                  (dragover)="$event.preventDefault()"
+                  (drop)="$event.preventDefault(); uploadAppIcon($event.dataTransfer.files[0])"
+                >
+                  <mat-icon class="em-dz-icon">cloud_upload</mat-icon>
+                  <p class="em-dz-title" i18n>Drag & drop or <span class="em-dz-link">browse</span></p>
+                  <p class="em-dz-meta" i18n>JPG, PNG · 760 × 400 px · max 1 MB</p>
+                </div>
 
-  </div><!-- /em-page -->
-  </div><!-- /edit-meta -->
+                <input
+                  type="file"
+                  #uploadThumbnail
+                  (change)="uploadAppIcon($event.target.files[0]); uploadThumbnail.value = null"
+                  style="display: none"
+                  [accept]="imageTypes.toString()"
+                />
+              </ng-container>
+            </div>
+          </div>
+
+          <!-- Card: Competencies -->
+          <div class="em-card">
+            <div class="em-card-header">
+              <span class="em-card-icon"><mat-icon>school</mat-icon></span>
+              <div>
+                <h3 class="em-card-title" i18n>Competencies</h3>
+                <p class="em-card-sub" i18n>Map required skills to this course</p>
+              </div>
+              <button mat-flat-button class="em-add-comp-btn" (click)="addCompetency()" type="button">
+                <mat-icon>add</mat-icon> <span i18n>Add</span>
+              </button>
+            </div>
+            <div class="em-card-body em-comp-body">
+              <!-- Empty state -->
+              <div *ngIf="!addedCompetency || addedCompetency?.length === 0" class="em-comp-empty">
+                <mat-icon class="em-comp-empty-icon">radar</mat-icon>
+                <p class="em-comp-empty-title" i18n>No competencies added yet</p>
+                <p class="em-comp-empty-sub" i18n>Add at least one competency before publishing</p>
+                <button mat-stroked-button class="em-comp-cta" (click)="addCompetency()" type="button">
+                  <mat-icon>add_circle_outline</mat-icon> <span i18n>Add Competency</span>
+                </button>
+              </div>
+
+              <!-- Competency cards -->
+              <div *ngIf="addedCompetency?.length > 0" class="em-comp-list">
+                <div *ngFor="let comp of addedCompetency; trackBy: trackByIndex" class="em-comp-chip">
+                  <div class="em-comp-info">
+                    <span class="em-comp-code">{{ comp.Code }}</span>
+                    <span class="em-comp-name">{{ comp.competencyName }}</span>
+                    <span *ngIf="comp.level" class="em-comp-level" i18n>Level {{ comp.level }}</span>
+                  </div>
+                  <button class="em-comp-del" type="button" (click)="deleteCompetancy(comp)" aria-label="Remove">
+                    <mat-icon>close</mat-icon>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- /em-col-right -->
+      </div>
+      <!-- /em-grid -->
+    </div>
+    <!-- /em-page -->
+  </div>
+  <!-- /edit-meta -->
 </form>

--- a/project/ws/author/src/lib/routing/modules/editor/shared/components/edit-meta/edit-meta.component.ts
+++ b/project/ws/author/src/lib/routing/modules/editor/shared/components/edit-meta/edit-meta.component.ts
@@ -17,6 +17,12 @@ import {
 
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms'
 
+import {
+  MAX_INSTRUCTIONS_BYTES,
+  maxByteLengthValidator,
+  utf8ByteLength,
+} from '@ws/author/src/lib/modules/shared/validators/byte-length.validator'
+
 import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete'
 import { MatChipInputEvent } from '@angular/material/chips'
 
@@ -68,7 +74,6 @@ import { CompetencyPopupComponent } from 'src/app/competency-popup/competency-po
 
 import { ConfirmDialogComponent } from '@ws/author/src/lib/modules/shared/components/confirm-dialog/confirm-dialog.component'
 
-
 import {
   debounceTime,
   distinctUntilChanged,
@@ -81,7 +86,6 @@ import {
 import { Router } from '@angular/router'
 
 import { NSApiRequest } from '../../../../../../interface/apiRequest'
-
 
 // import { ApiService } from '@ws/author/src/lib/modules/shared/services/api.service'
 
@@ -164,32 +168,30 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
   selfAssessment!: FormControl
   //issueCertification!: FormControl
   bucket: string = ''
-  certificateList: any[] = [
-    'Yes', 'No'
-  ]
+  certificateList: any[] = ['Yes', 'No']
   languageList: any[] = [
     {
-      "name": 'English',
-      "value": 'en'
+      name: 'English',
+      value: 'en',
     },
     {
-      "name": 'Hindi',
-      "value": 'hi'
+      name: 'Hindi',
+      value: 'hi',
     },
     {
-      "name": 'Kannada',
-      "value": 'kn'
+      name: 'Kannada',
+      value: 'kn',
     },
     {
-      "name": 'Assamese',
-      "value": 'as'
+      name: 'Assamese',
+      value: 'as',
     },
     {
-      "name": 'Odia',
-      "value": 'or'
+      name: 'Odia',
+      value: 'or',
     },
   ]
-  isAddCerticate: boolean = false;
+  isAddCerticate: boolean = false
   resourceDurat: any = []
   sumDuration: any
   proficiencyList: any
@@ -213,9 +215,9 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
   saveParent: any
   languageList$!: Observable<any[]>
   //UI variables
-  moduleName: string = 'undefined title';
-  isSaveModuleFormEnable: boolean = false;
-  moduleButtonName: string = 'Create';
+  moduleName: string = 'undefined title'
+  isSaveModuleFormEnable: boolean = false
+  moduleButtonName: string = 'Create'
   fieldActive!: boolean
   isFormValid!: boolean
   competencies: any
@@ -241,8 +243,6 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
     private http: HttpClient,
     private router: Router,
   ) {
-
-
     // this.authInitService.publishMessage.subscribe(
     //   (data: any) => {
     //     console.log("edit-meta", data)
@@ -429,14 +429,16 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
       )
       .subscribe(() => this.fetchRegion())
 
-    this.accessPathsCtrl.valueChanges.pipe(
-      debounceTime(400),
-      filter(v => v),
-    ).subscribe(() => this.fetchAccessRestrictions())
+    this.accessPathsCtrl.valueChanges
+      .pipe(
+        debounceTime(400),
+        filter(v => v),
+      )
+      .subscribe(() => this.fetchAccessRestrictions())
 
     this.saveTriggerSub = this.contentService.changeActiveCont.subscribe(data => {
       // tslint:disable-next-line:no-console
-      console.log("data", data)
+      console.log('data', data)
       if (this.contentMeta && this.canUpdate) {
         this.storeData()
       }
@@ -481,7 +483,7 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
     const dialogRef = this.dialog.open(CompetencyPopupComponent, {
       width: '40%',
       maxHeight: '90vh',
-      data: this.selectedSelfCompetency
+      data: this.selectedSelfCompetency,
     })
     dialogRef.afterClosed().subscribe((response: boolean) => {
       // Only refresh (and show the loader) when a competency was actually added.
@@ -515,64 +517,63 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
     dialogRef.afterClosed().subscribe((confirm: any) => {
       if (confirm) {
         this.loader.changeLoad.next(true)
-        this.editorService.checkReadAPI(id)
-          .subscribe(async (res: any) => {
-            data = await res.result.content
-            let competencyID: string
-            let arr1: string[] = []
-            let arr2: { competencyName: any; competencyId: any; level: any }[] = []
-            let requestBody: any
-            let meta
-            if (data.competencySearch === undefined) {
-              meta = {
-                versionKey: data.versionKey,
-                competencySearch: [],
-                competency: false,
-                competencies_v1: []
-              }
+        this.editorService.checkReadAPI(id).subscribe(async (res: any) => {
+          data = await res.result.content
+          let competencyID: string
+          let arr1: string[] = []
+          let arr2: { competencyName: any; competencyId: any; level: any }[] = []
+          let requestBody: any
+          let meta
+          if (data.competencySearch === undefined) {
+            meta = {
+              versionKey: data.versionKey,
+              competencySearch: [],
+              competency: false,
+              competencies_v1: [],
+            }
+          } else {
+            arr2 = JSON.parse(data.competencies_v1)
+            if (data.competencySearch) {
+              arr1 = data.competencySearch
+            }
+            if (competency.level) {
+              competencyID = competency.competencyId + '-' + competency.level.toString()
             } else {
-
-              arr2 = JSON.parse(data.competencies_v1)
-              if (data.competencySearch) {
-                arr1 = data.competencySearch
-              }
-              if (competency.level) {
-                competencyID = competency.competencyId + '-' + competency.level.toString()
-              } else {
-                competencyID = competency.competencyId
-              }
-              arr1 = arr1.filter(e => e !== competencyID)
-              for (var n = 0; n < arr2.length; n++) {
-                if (arr2[n].competencyName === competency.competencyName && arr2[n].competencyId === competency.competencyId && arr2[n].level === competency.level) {
-                  arr2.splice(n, 1)
-                  break
-                }
-              }
-
-              meta = {
-                versionKey: data.versionKey,
-                competencySearch: arr1,
-                competency: false,
-                competencies_v1: arr2
+              competencyID = competency.competencyId
+            }
+            arr1 = arr1.filter(e => e !== competencyID)
+            for (var n = 0; n < arr2.length; n++) {
+              if (
+                arr2[n].competencyName === competency.competencyName &&
+                arr2[n].competencyId === competency.competencyId &&
+                arr2[n].level === competency.level
+              ) {
+                arr2.splice(n, 1)
+                break
               }
             }
 
-            requestBody = {
-              request: {
-                content: meta
-              }
+            meta = {
+              versionKey: data.versionKey,
+              competencySearch: arr1,
+              competency: false,
+              competencies_v1: arr2,
             }
-            this.editorService.updateNewContentV3(requestBody, id)
-              .subscribe(
-                (response: any) => {
-                  if (response) {
-                    this.loadCompetancy()
-                  }
-                })
+          }
+
+          requestBody = {
+            request: {
+              content: meta,
+            },
+          }
+          this.editorService.updateNewContentV3(requestBody, id).subscribe((response: any) => {
+            if (response) {
+              this.loadCompetancy()
+            }
           })
+        })
       }
     })
-
   }
 
   checkMandatoryFields() {
@@ -678,8 +679,7 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
   changeCertificate(event: any): void {
     if (event == 'Yes') {
       this.isAddCerticate = true
-    }
-    else {
+    } else {
       this.isAddCerticate = false
     }
   }
@@ -709,8 +709,7 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
   }
 
   private set content(contentMeta: NSContent.IContentMeta) {
-    const isCreator = (this.configSvc.userProfile && this.configSvc.userProfile.userId === contentMeta.createdBy)
-      ? true : false
+    const isCreator = this.configSvc.userProfile && this.configSvc.userProfile.userId === contentMeta.createdBy ? true : false
 
     this.contentMeta = contentMeta
 
@@ -740,9 +739,7 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
     this.canExpiry = this.contentMeta.expiryDate !== '99991231T235959+0000'
     if (this.canExpiry) {
       this.contentMeta.expiryDate =
-        contentMeta.expiryDate && contentMeta.expiryDate.indexOf('+') === 15
-          ? <any>this.convertToISODate(contentMeta.expiryDate)
-          : ''
+        contentMeta.expiryDate && contentMeta.expiryDate.indexOf('+') === 15 ? <any>this.convertToISODate(contentMeta.expiryDate) : ''
     }
     this.contentService.currentContentData = this.contentMeta
     this.contentService.currentContentID = this.contentMeta.identifier
@@ -763,32 +760,32 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
     this.ordinals.complexityLevel.map((v: any) => {
       if (v.condition) {
         let canAdd = false
-          // tslint:disable-next-line: whitespace
-          ; (v.condition.showFor || []).map((con: any) => {
-            let innerCondition = false
-            Object.keys(con).map(meta => {
-              if (
-                con[meta].indexOf(
-                  (this.contentForm.controls[meta] && this.contentForm.controls[meta].value) ||
+        // tslint:disable-next-line: whitespace
+        ;(v.condition.showFor || []).map((con: any) => {
+          let innerCondition = false
+          Object.keys(con).map(meta => {
+            if (
+              con[meta].indexOf(
+                (this.contentForm.controls[meta] && this.contentForm.controls[meta].value) ||
                   this.contentMeta[meta as keyof NSContent.IContentMeta],
-                ) > -1
-              ) {
-                innerCondition = true
-              }
-            })
-            if (innerCondition) {
-              canAdd = true
+              ) > -1
+            ) {
+              innerCondition = true
             }
           })
+          if (innerCondition) {
+            canAdd = true
+          }
+        })
         if (canAdd) {
           // tslint:disable-next-line: semicolon // tslint:disable-next-line: whitespace
-          ; (v.condition.nowShowFor || []).map((con: any) => {
+          ;(v.condition.nowShowFor || []).map((con: any) => {
             let innerCondition = false
             Object.keys(con).map(meta => {
               if (
                 con[meta].indexOf(
                   (this.contentForm.controls[meta] && this.contentForm.controls[meta].value) ||
-                  this.contentMeta[meta as keyof NSContent.IContentMeta],
+                    this.contentMeta[meta as keyof NSContent.IContentMeta],
                 ) < 0
               ) {
                 innerCondition = true
@@ -815,9 +812,7 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
   assignExpiryDate() {
     this.canExpiry = !this.canExpiry
     this.contentForm.controls.expiryDate.setValue(
-      this.canExpiry
-        ? new Date(new Date().setMonth(new Date().getMonth() + 6))
-        : '99991231T235959+0000',
+      this.canExpiry ? new Date(new Date().setMonth(new Date().getMonth() + 6)) : '99991231T235959+0000',
     )
   }
   assignFields() {
@@ -832,83 +827,86 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
     this.loader.changeLoad.next(true)
     const url = this.router.url
     const id = url.split('/')
-    this.editorService.readcontentV3(id[3]).subscribe((res: any) => {
-      // tslint:disable-next-line:no-console
-      console.log(res)
-      this.contentMeta = res
-      this.contentMeta = res
-      this.contentForm.controls.name.setValue(res.name)
-      this.contentForm.controls.appIcon.setValue(res.appIcon)
-      this.contentForm.controls.thumbnail.setValue(res.appIcon)
-      this.contentForm.controls.instructions.setValue(res.instructions)
-      this.contentForm.controls.lang.setValue(res.lang)
-      this.contentForm.controls.subTitle.setValue(res.subTitle)
-      this.contentForm.controls.sourceName.setValue(res.sourceName)
-      this.contentForm.controls.gatingEnabled.setValue(res.gatingEnabled)
-      this.contentForm.controls.courseVisibility.setValue(res.courseVisibility)
-      this.contentForm.controls.selfAssessment.setValue(res.selfAssessment)
-      if (this.contentForm.controls.selfAssessment.value) {
-        this.selectedSelfCompetency = true
-      }
-      if (res.competencies_v1) {
-        this.getAllEntity()
-        this.competencies = JSON.parse(res.competencies_v1)
-        console.log("this.competencies", res)
-      } else {
-        this.competencies = []
-      }
-      // Latest server data is now in the form — safe to reveal the gated fields.
-      this.metaLoaded = true
-      if (res.children.length > 0) {
-        this.loader.changeLoad.next(true)
-        res.children.forEach((element: any) => {
-          if (element.duration) {
-            this.resourceDurat.push(parseInt(element.duration))
-          }
-          if (element.children && element.children.length > 0) {
-            element.children.forEach((ele: any) => {
-              if (ele.duration) {
-                this.resourceDurat.push(parseInt(ele.duration))
-              }
-            })
-          }
-        })
+    this.editorService.readcontentV3(id[3]).subscribe(
+      (res: any) => {
         // tslint:disable-next-line:no-console
-        console.log(this.resourceDurat)
-        if (this.resourceDurat.length > 0) {
-          this.sumDuration = this.resourceDurat.reduce((a: any, b: any) => a + b)
+        console.log(res)
+        this.contentMeta = res
+        this.contentMeta = res
+        this.contentForm.controls.name.setValue(res.name)
+        this.contentForm.controls.appIcon.setValue(res.appIcon)
+        this.contentForm.controls.thumbnail.setValue(res.appIcon)
+        this.contentForm.controls.instructions.setValue(res.instructions)
+        this.contentForm.controls.lang.setValue(res.lang)
+        this.contentForm.controls.subTitle.setValue(res.subTitle)
+        this.contentForm.controls.sourceName.setValue(res.sourceName)
+        this.contentForm.controls.gatingEnabled.setValue(res.gatingEnabled)
+        this.contentForm.controls.courseVisibility.setValue(res.courseVisibility)
+        this.contentForm.controls.selfAssessment.setValue(res.selfAssessment)
+        if (this.contentForm.controls.selfAssessment.value) {
+          this.selectedSelfCompetency = true
+        }
+        if (res.competencies_v1) {
+          this.getAllEntity()
+          this.competencies = JSON.parse(res.competencies_v1)
+          console.log('this.competencies', res)
+        } else {
+          this.competencies = []
+        }
+        // Latest server data is now in the form — safe to reveal the gated fields.
+        this.metaLoaded = true
+        if (res.children.length > 0) {
+          this.loader.changeLoad.next(true)
+          res.children.forEach((element: any) => {
+            if (element.duration) {
+              this.resourceDurat.push(parseInt(element.duration))
+            }
+            if (element.children && element.children.length > 0) {
+              element.children.forEach((ele: any) => {
+                if (ele.duration) {
+                  this.resourceDurat.push(parseInt(ele.duration))
+                }
+              })
+            }
+          })
           // tslint:disable-next-line:no-console
-          console.log(this.sumDuration.toString(), this.contentMeta.duration)
-          if (this.sumDuration.toString() !== this.contentMeta.duration) {
-            let requestBody: any
-            requestBody = {
-              request: {
-                content: {
-                  duration: isNumber(this.sumDuration) ?
-                    this.sumDuration.toString() : this.sumDuration,
-                  versionKey: res.versionKey
+          console.log(this.resourceDurat)
+          if (this.resourceDurat.length > 0) {
+            this.sumDuration = this.resourceDurat.reduce((a: any, b: any) => a + b)
+            // tslint:disable-next-line:no-console
+            console.log(this.sumDuration.toString(), this.contentMeta.duration)
+            if (this.sumDuration.toString() !== this.contentMeta.duration) {
+              let requestBody: any
+              requestBody = {
+                request: {
+                  content: {
+                    duration: isNumber(this.sumDuration) ? this.sumDuration.toString() : this.sumDuration,
+                    versionKey: res.versionKey,
+                  },
                 },
               }
+              this.editorService
+                .updateNewContentV3(_.omit(requestBody, ['resourceType']), this.contentMeta.identifier)
+                .subscribe((response: any) => {
+                  // tslint:disable-next-line:no-console
+                  console.log(response)
+                })
             }
-            this.editorService.updateNewContentV3(_.omit(requestBody, ['resourceType']), this.contentMeta.identifier).subscribe((response: any) => {
-              // tslint:disable-next-line:no-console
-              console.log(response)
-            })
+            this.loader.changeLoad.next(false)
+            this.setDuration(this.sumDuration)
           }
           this.loader.changeLoad.next(false)
-          this.setDuration(this.sumDuration)
+        } else {
+          this.loader.changeLoad.next(false)
         }
+      },
+      () => {
+        // On read failure, still reveal the fields and hide the loader so the form
+        // isn't stuck behind the overlay.
+        this.metaLoaded = true
         this.loader.changeLoad.next(false)
-      } else {
-        this.loader.changeLoad.next(false)
-      }
-
-    }, () => {
-      // On read failure, still reveal the fields and hide the loader so the form
-      // isn't stuck behind the overlay.
-      this.metaLoaded = true
-      this.loader.changeLoad.next(false)
-    })
+      },
+    )
     Object.keys(this.contentForm.controls).map(v => {
       try {
         if (
@@ -919,9 +917,7 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
           this.contentForm.controls[v].setValue(this.contentMeta[v as keyof NSContent.IContentMeta])
         } else {
           if (v === 'expiryDate') {
-            this.contentForm.controls[v].setValue(
-              new Date(new Date().setMonth(new Date().getMonth() + 60)),
-            )
+            this.contentForm.controls[v].setValue(new Date(new Date().setMonth(new Date().getMonth() + 60)))
           } else {
             this.contentForm.controls[v].setValue(
               JSON.parse(
@@ -939,7 +935,9 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
         this.contentForm.controls.sourceName.setValue(this.contentMeta.sourceName)
         this.contentForm.controls.lang.setValue(this.contentMeta.lang)
         this.contentForm.controls.gatingEnabled.setValue(this.contentMeta.gatingEnabled)
-        this.contentForm.controls.issueCertification.setValue(this.contentMeta.issueCertification === undefined ? false : this.contentMeta.issueCertification)
+        this.contentForm.controls.issueCertification.setValue(
+          this.contentMeta.issueCertification === undefined ? false : this.contentMeta.issueCertification,
+        )
 
         if (this.contentMeta.competencies_v1) {
           // this.getAllEntity()
@@ -952,7 +950,7 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
           this.contentForm.controls[v].markAsPristine()
           this.contentForm.controls[v].markAsUntouched()
         }
-      } catch (ex) { }
+      } catch (ex) {}
     })
     this.canUpdate = true
     this.storeData()
@@ -974,7 +972,7 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
 
           const finalComp = {
             ...element,
-            ...matchingValue.additionalProperties
+            ...matchingValue.additionalProperties,
           }
           return finalComp
         })
@@ -1056,8 +1054,14 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
       if (originalMeta && this.isEditEnabled) {
         const expiryDate = this.contentForm.value.expiryDate
         const currentMeta: NSContent.IContentMeta = JSON.parse(JSON.stringify(this.contentForm.value))
-        const exemptArray = ['application/quiz', 'application/x-mpegURL', 'audio/mpeg', 'video/mp4',
-          'application/vnd.ekstep.html-archive', 'application/json']
+        const exemptArray = [
+          'application/quiz',
+          'application/x-mpegURL',
+          'audio/mpeg',
+          'video/mp4',
+          'application/vnd.ekstep.html-archive',
+          'application/json',
+        ]
         if (exemptArray.includes(originalMeta.mimeType)) {
           currentMeta.artifactUrl = originalMeta.artifactUrl
           currentMeta.mimeType = originalMeta.mimeType
@@ -1105,8 +1109,6 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
             }
             if (!currentMeta.lang) {
               currentMeta.lang = parentData.lang !== '' ? parentData.lang : currentMeta.lang
-
-
             }
           }
         }
@@ -1120,26 +1122,27 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
 
         const meta = <any>{}
         if (this.canExpiry) {
-          currentMeta.expiryDate = `${expiryDate
-            .toISOString()
-            .replace(/-/g, '')
-            .replace(/:/g, '')
-            .split('.')[0]
-            }+0000`
+          currentMeta.expiryDate = `${expiryDate.toISOString().replace(/-/g, '').replace(/:/g, '').split('.')[0]}+0000`
         }
         Object.keys(currentMeta).map(v => {
           if (
-            v !== 'versionKey' && v !== 'visibility' &&
+            v !== 'versionKey' &&
+            v !== 'visibility' &&
             JSON.stringify(currentMeta[v as keyof NSContent.IContentMeta]) !==
-            JSON.stringify(originalMeta[v as keyof NSContent.IContentMeta]) && v !== 'jobProfile'
+              JSON.stringify(originalMeta[v as keyof NSContent.IContentMeta]) &&
+            v !== 'jobProfile'
           ) {
             if (
               currentMeta[v as keyof NSContent.IContentMeta] ||
               // (this.authInitService.authConfig[v as keyof IFormMeta].type === 'boolean' &&
-              currentMeta[v as keyof NSContent.IContentMeta] === false) {
+              currentMeta[v as keyof NSContent.IContentMeta] === false
+            ) {
               meta[v as keyof NSContent.IContentMeta] = currentMeta[v as keyof NSContent.IContentMeta]
             } else {
-              if (this.authInitService.authConfig[v as keyof IFormMeta] && this.authInitService.authConfig[v as keyof IFormMeta].defaultValue) {
+              if (
+                this.authInitService.authConfig[v as keyof IFormMeta] &&
+                this.authInitService.authConfig[v as keyof IFormMeta].defaultValue
+              ) {
                 if (v !== 'isIframeSupported') {
                   meta[v as keyof NSContent.IContentMeta] = JSON.parse(
                     JSON.stringify(
@@ -1151,7 +1154,6 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
                   )
                 }
               }
-
             }
           } else if (v === 'versionKey') {
             meta[v as keyof NSContent.IContentMeta] = originalMeta[v as keyof NSContent.IContentMeta]
@@ -1180,7 +1182,6 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
           delete meta.artifactUrl
         }
         this.contentService.setUpdatedMeta(meta, this.contentMeta.identifier)
-
       }
     } catch (ex) {
       // tslint:disable-next-line:no-console
@@ -1258,9 +1259,7 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
     const value = (event.value || '').trim()
     if (value) {
       this.contentForm.controls.creatorDetails.value.push({ id: '', name: value })
-      this.contentForm.controls.creatorDetails.setValue(
-        this.contentForm.controls.creatorDetails.value,
-      )
+      this.contentForm.controls.creatorDetails.setValue(this.contentForm.controls.creatorDetails.value)
     }
     // Reset the input value
     if (input) {
@@ -1271,9 +1270,7 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
   removeCreatorDetails(keyword: any): void {
     const index = this.contentForm.controls.creatorDetails.value.indexOf(keyword)
     this.contentForm.controls.creatorDetails.value.splice(index, 1)
-    this.contentForm.controls.creatorDetails.setValue(
-      this.contentForm.controls.creatorDetails.value,
-    )
+    this.contentForm.controls.creatorDetails.setValue(this.contentForm.controls.creatorDetails.value)
   }
 
   addToFormControl(event: MatAutocompleteSelectedEvent, fieldName: string): void {
@@ -1473,16 +1470,7 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
   uploadAppIcon(file: File) {
     const formdata = new FormData()
     const fileName = file.name.replace(/[^A-Za-z0-9.]/g, '')
-    if (
-      !(
-        IMAGE_SUPPORT_TYPES.indexOf(
-          `.${fileName
-            .toLowerCase()
-            .split('.')
-            .pop()}`,
-        ) > -1
-      )
-    ) {
+    if (!(IMAGE_SUPPORT_TYPES.indexOf(`.${fileName.toLowerCase().split('.').pop()}`) > -1)) {
       this.snackBar.openFromComponent(NotificationComponent, {
         data: {
           type: Notify.INVALID_FORMAT,
@@ -1509,11 +1497,9 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
       img.src = reader.result as string
       img.onload = () => {
         if (img.width < 760 || img.height < 400) {
-          this.snackBar.open(
-            `Image resolution must be at least 760 x 400 px. Current: ${img.width} x ${img.height} px`,
-            undefined,
-            { duration: 4000 },
-          )
+          this.snackBar.open(`Image resolution must be at least 760 x 400 px. Current: ${img.width} x ${img.height} px`, undefined, {
+            duration: 4000,
+          })
           return
         }
         this.openThumbnailCropDialog(file, fileName, formdata)
@@ -1561,113 +1547,105 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
             },
           }
 
-          this.http
-            .post<NSApiRequest.ICreateMetaRequest>(
-              `${AUTHORING_BASE}content/v3/create`,
-              requestBody,
-            )
-            .subscribe(
-              (meta: any) => {
-                // return data.result.identifier
-                this.uploadService
-                  .upload(formdata, {
-                    contentId: meta.result.identifier,
-                    contentType: CONTENT_BASE_STATIC,
+          this.http.post<NSApiRequest.ICreateMetaRequest>(`${AUTHORING_BASE}content/v3/create`, requestBody).subscribe((meta: any) => {
+            // return data.result.identifier
+            this.uploadService
+              .upload(formdata, {
+                contentId: meta.result.identifier,
+                contentType: CONTENT_BASE_STATIC,
+              })
+
+              .subscribe(
+                data => {
+                  if (data && data.name !== 'Error') {
+                    // const generateURL = this.generateUrl(data.artifactUrl)
+                    // const updateArtf: NSApiRequest.IUpdateImageMetaRequestV2 = {
+                    //   request: {
+                    //     content: {
+                    //       // content_url: data.result.artifactUrl,
+                    //       // identifier: data.result.identifier,
+                    //       // node_id: data.result.node_id,
+                    //       thumbnail: generateURL,
+                    //       appIcon: generateURL,
+                    //       artifactUrl: generateURL,
+                    //       // versionKey: (new Date()).getTime().toString(),
+                    //       versionKey: meta.result.versionKey,
+                    //     },
+                    //   },
+                    // }
+
+                    // this.apiService
+                    //   .patch<NSApiRequest.ICreateMetaRequest>(
+                    //     `${AUTHORING_BASE}content/v3/update/${data.identifier}`,
+                    //     updateArtf,
+                    //   )
+                    // this.editorService.checkReadAPI(data.identifier)
+                    // .subscribe(
+                    //   (res: any) => {
+                    //     console.log(res)
+                    //     if (res) {
+                    //     }
+                    this.loader.changeLoad.next(false)
+                    this.canUpdate = false
+                    this.contentForm.controls.appIcon.setValue(this.generateUrl(data.artifactUrl))
+                    this.contentForm.controls.thumbnail.setValue(this.generateUrl(data.artifactUrl))
+                    this.canUpdate = true
+                    // this.data.emit('save')
+                    this.storeData()
+                    this.authInitService.uploadData('thumbnail')
+                    // this.contentForm.controls.posterImage.setValue(data.artifactURL)
+                    this.snackBar.openFromComponent(NotificationComponent, {
+                      data: {
+                        type: Notify.UPLOAD_SUCCESS,
+                      },
+                      duration: NOTIFICATION_TIME * 2000,
+                    })
+                    // })
+                  } else {
+                    this.loader.changeLoad.next(false)
+                    this.snackBar.open(data.message, undefined, { duration: 2000 })
+                  }
+                },
+                () => {
+                  this.loader.changeLoad.next(false)
+                  this.snackBar.openFromComponent(NotificationComponent, {
+                    data: {
+                      type: Notify.UPLOAD_FAIL,
+                    },
+                    duration: NOTIFICATION_TIME * 1000,
                   })
+                },
+              )
 
-                  .subscribe(
-                    data => {
-                      if (data && data.name !== 'Error') {
-                        // const generateURL = this.generateUrl(data.artifactUrl)
-                        // const updateArtf: NSApiRequest.IUpdateImageMetaRequestV2 = {
-                        //   request: {
-                        //     content: {
-                        //       // content_url: data.result.artifactUrl,
-                        //       // identifier: data.result.identifier,
-                        //       // node_id: data.result.node_id,
-                        //       thumbnail: generateURL,
-                        //       appIcon: generateURL,
-                        //       artifactUrl: generateURL,
-                        //       // versionKey: (new Date()).getTime().toString(),
-                        //       versionKey: meta.result.versionKey,
-                        //     },
-                        //   },
-                        // }
-
-                        // this.apiService
-                        //   .patch<NSApiRequest.ICreateMetaRequest>(
-                        //     `${AUTHORING_BASE}content/v3/update/${data.identifier}`,
-                        //     updateArtf,
-                        //   )
-                        // this.editorService.checkReadAPI(data.identifier)
-                        // .subscribe(
-                        //   (res: any) => {
-                        //     console.log(res)
-                        //     if (res) {
-                        //     }
-                        this.loader.changeLoad.next(false)
-                        this.canUpdate = false
-                        this.contentForm.controls.appIcon.setValue(this.generateUrl(data.artifactUrl))
-                        this.contentForm.controls.thumbnail.setValue(this.generateUrl(data.artifactUrl))
-                        this.canUpdate = true
-                        // this.data.emit('save')
-                        this.storeData()
-                        this.authInitService.uploadData('thumbnail')
-                        // this.contentForm.controls.posterImage.setValue(data.artifactURL)
-                        this.snackBar.openFromComponent(NotificationComponent, {
-                          data: {
-                            type: Notify.UPLOAD_SUCCESS,
-                          },
-                          duration: NOTIFICATION_TIME * 2000,
-                        })
-                        // })
-                      } else {
-                        this.loader.changeLoad.next(false)
-                        this.snackBar.open(data.message, undefined, { duration: 2000 })
-                      }
-                    },
-                    () => {
-                      this.loader.changeLoad.next(false)
-                      this.snackBar.openFromComponent(NotificationComponent, {
-                        data: {
-                          type: Notify.UPLOAD_FAIL,
-                        },
-                        duration: NOTIFICATION_TIME * 1000,
-                      })
-                    },
-                  )
-
-                // .subscribe(
-                //   data => {
-                //     if (data.result) {
-                //       this.loader.changeLoad.next(false)
-                //       this.canUpdate = false
-                //       this.contentForm.controls.appIcon.setValue(data.result.artifactUrl)
-                //       this.contentForm.controls.thumbnail.setValue(data.result.artifactUrl)
-                //       // this.contentForm.controls.posterImage.setValue(data.artifactURL)
-                //       this.canUpdate = true
-                //       this.storeData()
-                //       this.snackBar.openFromComponent(NotificationComponent, {
-                //         data: {
-                //           type: Notify.UPLOAD_SUCCESS,
-                //         },
-                //         duration: NOTIFICATION_TIME * 1000,
-                //       })
-                //     }
-                //   },
-                //   () => {
-                //     this.loader.changeLoad.next(false)
-                //     this.snackBar.openFromComponent(NotificationComponent, {
-                //       data: {
-                //         type: Notify.UPLOAD_FAIL,
-                //       },
-                //       duration: NOTIFICATION_TIME * 1000,
-                //     })
-                //   },
-                // )
-              },
-            )
-
+            // .subscribe(
+            //   data => {
+            //     if (data.result) {
+            //       this.loader.changeLoad.next(false)
+            //       this.canUpdate = false
+            //       this.contentForm.controls.appIcon.setValue(data.result.artifactUrl)
+            //       this.contentForm.controls.thumbnail.setValue(data.result.artifactUrl)
+            //       // this.contentForm.controls.posterImage.setValue(data.artifactURL)
+            //       this.canUpdate = true
+            //       this.storeData()
+            //       this.snackBar.openFromComponent(NotificationComponent, {
+            //         data: {
+            //           type: Notify.UPLOAD_SUCCESS,
+            //         },
+            //         duration: NOTIFICATION_TIME * 1000,
+            //       })
+            //     }
+            //   },
+            //   () => {
+            //     this.loader.changeLoad.next(false)
+            //     this.snackBar.openFromComponent(NotificationComponent, {
+            //       data: {
+            //         type: Notify.UPLOAD_FAIL,
+            //       },
+            //       duration: NOTIFICATION_TIME * 1000,
+            //     })
+            //   },
+            // )
+          })
         }
       },
     })
@@ -1675,16 +1653,7 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
   uploadSourceIcon(file: File) {
     const formdata = new FormData()
     const fileName = file.name.replace(/[^A-Za-z0-9.]/g, '')
-    if (
-      !(
-        IMAGE_SUPPORT_TYPES.indexOf(
-          `.${fileName
-            .toLowerCase()
-            .split('.')
-            .pop()}`,
-        ) > -1
-      )
-    ) {
+    if (!(IMAGE_SUPPORT_TYPES.indexOf(`.${fileName.toLowerCase().split('.').pop()}`) > -1)) {
       this.snackBar.openFromComponent(NotificationComponent, {
         data: {
           type: Notify.INVALID_FORMAT,
@@ -1759,17 +1728,14 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
     })
   }
   changeToDefaultImg($event: any) {
-    $event.target.src = this.configSvc.instanceConfig
-      ? this.configSvc.instanceConfig.logos.defaultContent
-      : ''
+    $event.target.src = this.configSvc.instanceConfig ? this.configSvc.instanceConfig.logos.defaultContent : ''
   }
-
 
   generateUrl(oldUrl: any) {
     //const chunk = oldUrl.split('/')
     //const newChunk = environment.azureHost.split('/')
     // @ts-ignore: Unreachable code error
-    this.bucket = window["env"]["azureBucket"]
+    this.bucket = window['env']['azureBucket']
     if (oldUrl.includes(this.bucket)) {
       return oldUrl
     }
@@ -1816,21 +1782,21 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
   addEmployee(event: MatAutocompleteSelectedEvent, field: string) {
     if (event.option.value && event.option.value.id) {
       this.loader.changeLoad.next(true)
-      const observable = ['trackContacts', 'publisherDetails'].includes(field) &&
-        this.accessService.authoringConfig.doUniqueCheck
-        ? this.editorService
-          .checkRole(event.option.value.id)
-          .pipe(
-            map(
-              (v: string[]) =>
-                v.includes('admin') ||
-                v.includes('editor') ||
-                (field === 'trackContacts' && v.includes('reviewer')) ||
-                (field === 'publisherDetails' && v.includes('publisher')) ||
-                (field === 'publisherDetails' && event.option.value.id === this.accessService.userId),
-            ),
-          )
-        : of(true)
+      const observable =
+        ['trackContacts', 'publisherDetails'].includes(field) && this.accessService.authoringConfig.doUniqueCheck
+          ? this.editorService
+              .checkRole(event.option.value.id)
+              .pipe(
+                map(
+                  (v: string[]) =>
+                    v.includes('admin') ||
+                    v.includes('editor') ||
+                    (field === 'trackContacts' && v.includes('reviewer')) ||
+                    (field === 'publisherDetails' && v.includes('publisher')) ||
+                    (field === 'publisherDetails' && event.option.value.id === this.accessService.userId),
+                ),
+              )
+          : of(true)
       observable.subscribe(
         (data: boolean) => {
           if (data) {
@@ -1876,9 +1842,7 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
 
   private fetchAudience() {
     if ((this.audienceCtrl.value || '').trim()) {
-      this.audienceList = this.ordinals.audience.filter(
-        (v: any) => v.toLowerCase().indexOf(this.audienceCtrl.value.toLowerCase()) > -1,
-      )
+      this.audienceList = this.ordinals.audience.filter((v: any) => v.toLowerCase().indexOf(this.audienceCtrl.value.toLowerCase()) > -1)
     } else {
       this.audienceList = this.ordinals.audience.slice()
     }
@@ -1896,9 +1860,7 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
 
   private fetchRegion() {
     if ((this.regionCtrl.value || '').trim()) {
-      this.regionList = this.ordinals.region.filter(
-        (v: any) => v.toLowerCase().indexOf(this.regionCtrl.value.toLowerCase()) > -1,
-      )
+      this.regionList = this.ordinals.region.filter((v: any) => v.toLowerCase().indexOf(this.regionCtrl.value.toLowerCase()) > -1)
     } else {
       this.regionList = []
     }
@@ -1906,11 +1868,23 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
 
   private fetchAccessRestrictions() {
     if (this.accessPathsCtrl.value.trim()) {
-      this.accessPathList = this.ordinals.accessPaths.filter((v: any) => v.toLowerCase().
-        indexOf(this.accessPathsCtrl.value.toLowerCase()) === 0)
+      this.accessPathList = this.ordinals.accessPaths.filter(
+        (v: any) => v.toLowerCase().indexOf(this.accessPathsCtrl.value.toLowerCase()) === 0,
+      )
     } else {
       this.accessPathList = this.ordinals.accessPaths.slice()
     }
+  }
+
+  // Byte budget for the course Description (`instructions`) — drives the counter and
+  // the over-limit message. Capped in UTF-8 bytes (not chars) because the search
+  // indexer's Elasticsearch keyword limit is byte-based; see byte-length.validator.ts.
+  get maxInstructionsBytes(): number {
+    return MAX_INSTRUCTIONS_BYTES
+  }
+
+  get instructionsByteLength(): number {
+    return utf8ByteLength(this.contentForm && this.contentForm.controls.instructions ? this.contentForm.controls.instructions.value : '')
   }
 
   checkCondition(meta: string, type: 'show' | 'required' | 'disabled'): boolean {
@@ -2006,22 +1980,20 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
       unit: [],
       verifiers: [],
       visibility: [],
-      instructions: new FormControl('', [Validators.required]),
-      versionKey: '',  // (new Date()).getTime()
+      instructions: new FormControl('', [Validators.required, maxByteLengthValidator(MAX_INSTRUCTIONS_BYTES)]),
+      versionKey: '', // (new Date()).getTime()
       purpose: '',
       lang: new FormControl('', [Validators.required]),
-      cneName: new FormControl('')
+      cneName: new FormControl(''),
     })
     // tslint:disable-next-line:no-console
-    console.log("form validation", this.contentForm)
+    console.log('form validation', this.contentForm)
 
     // Tell the parent stepper whether the course-details form is currently valid,
     // both now (initial state) and on every subsequent status change, so it can
     // keep the Next button disabled until all mandatory fields are filled.
     this.validityChange.emit(this.contentForm.valid)
-    this.contentForm.statusChanges
-      .pipe(distinctUntilChanged())
-      .subscribe(() => this.validityChange.emit(this.contentForm.valid))
+    this.contentForm.statusChanges.pipe(distinctUntilChanged()).subscribe(() => this.validityChange.emit(this.contentForm.valid))
 
     this.contentForm.valueChanges.pipe(debounceTime(500)).subscribe(() => {
       if (this.canUpdate) {
@@ -2045,9 +2017,7 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
 
     if (this.stage === 1) {
       this.contentForm.controls.creatorContacts.valueChanges.subscribe(() => {
-        this.contentForm.controls.publisherDetails.setValue(
-          this.contentForm.controls.creatorContacts.value || [],
-        )
+        this.contentForm.controls.publisherDetails.setValue(this.contentForm.controls.creatorContacts.value || [])
       })
     }
 
@@ -2064,9 +2034,7 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
     })
 
     this.contentForm.controls.resourceCategory.valueChanges.subscribe(() => {
-      this.contentForm.controls.customClassifiers.setValue(
-        this.contentForm.controls.resourceCategory.value,
-      )
+      this.contentForm.controls.customClassifiers.setValue(this.contentForm.controls.resourceCategory.value)
     })
   }
 
@@ -2181,5 +2149,4 @@ export class EditMetaComponent implements OnInit, OnChanges, OnDestroy, AfterVie
     this.isSaveModuleFormEnable = true
     this.moduleButtonName = 'Save'
   }
-
 }


### PR DESCRIPTION
## Summary
Two authoring bug fixes for the 5.0.x line:

- **Show Correct Answer Popup → Assessment only.** It was appearing on non-assessment resources (e.g. PDF) because the check only looked at `content.isAssessment`, which can leak truthy. Now gated on a new `isAssessmentResource` getter (assessment mimeType + isAssessment + not self-assessment); save paths hardened too.
- **Course Description capped at 24,000 UTF-8 bytes.** A Hindi + Word/Docs-pasted description (~34,939 bytes) exceeded Elasticsearch's 32,766-byte keyword limit, crash-looping the composite search indexer so new courses never appeared in Drafts. A reusable `maxByteLengthValidator` blocks over-limit descriptions with a live byte counter.

## Tests
Unit tests for both (`isAssessmentResource` cases; byte validator: ASCII/Hindi/empty/limit). All green.

## Notes
The byte cap prevents new oversized descriptions; the already-saved oversized course still needs the backend indexer record skipped/reindexed.