### PR TITLE
fix(author): restore image/file/blank upload buttons in the question CKEditor

### DIFF
--- a/project/ws/author/src/lib/routing/modules/editor/routing/modules/quiz/components/quiz/quiz.component.spec.ts
+++ b/project/ws/author/src/lib/routing/modules/editor/routing/modules/quiz/components/quiz/quiz.component.spec.ts
@@ -89,4 +89,28 @@ describe('QuizComponent', () => {
       expect([...result].sort()).toEqual(input)
     })
   })
+
+  describe('shouldPreserveUnsavedQuestions', () => {
+    it('preserves in-memory questions when the store is dirty and already loaded for the id', () => {
+      // A background reload must not overwrite unsaved edits (e.g. a just-inserted image).
+      const { component, quizStoreSvc } = build()
+      ;(quizStoreSvc as any).hasChanged = true
+      ;(quizStoreSvc as any).collectiveQuiz = { c1: [{ question: 'q' }] }
+      expect(component.shouldPreserveUnsavedQuestions('c1')).toBe(true)
+    })
+
+    it('allows a backend load on a clean (unmodified) store', () => {
+      const { component, quizStoreSvc } = build()
+      ;(quizStoreSvc as any).hasChanged = false
+      ;(quizStoreSvc as any).collectiveQuiz = { c1: [{ question: 'q' }] }
+      expect(component.shouldPreserveUnsavedQuestions('c1')).toBe(false)
+    })
+
+    it('allows a backend load when the id has no questions yet (fresh navigation)', () => {
+      const { component, quizStoreSvc } = build()
+      ;(quizStoreSvc as any).hasChanged = true
+      ;(quizStoreSvc as any).collectiveQuiz = {}
+      expect(component.shouldPreserveUnsavedQuestions('c2')).toBe(false)
+    })
+  })
 })

--- a/project/ws/author/src/lib/routing/modules/editor/routing/modules/quiz/components/quiz/quiz.component.ts
+++ b/project/ws/author/src/lib/routing/modules/editor/routing/modules/quiz/components/quiz/quiz.component.ts
@@ -1,6 +1,17 @@
 import { DeleteDialogComponent } from '@ws/author/src/lib/modules/shared/components/delete-dialog/delete-dialog.component'
 
-import { Component, OnInit, ChangeDetectorRef, OnDestroy, Input, Output, EventEmitter, OnChanges, ElementRef, ViewChild } from '@angular/core'
+import {
+  Component,
+  OnInit,
+  ChangeDetectorRef,
+  OnDestroy,
+  Input,
+  Output,
+  EventEmitter,
+  OnChanges,
+  ElementRef,
+  ViewChild,
+} from '@angular/core'
 
 import { MatSnackBar, MatSnackBarRef } from '@angular/material/snack-bar'
 
@@ -15,7 +26,6 @@ import { forkJoin, of, Observable, Subscription, EMPTY } from 'rxjs'
 import { MatDialog } from '@angular/material/dialog'
 import { ActivatedRoute, Router } from '@angular/router'
 
-
 import { NotificationComponent } from '@ws/author/src/lib/modules/shared/components/notification/notification.component'
 
 import { CommentsDialogComponent } from '@ws/author/src/lib/modules/shared/components/comments-dialog/comments-dialog.component'
@@ -23,7 +33,6 @@ import { CommentsDialogComponent } from '@ws/author/src/lib/modules/shared/compo
 import { ConfirmDialogComponent } from '@ws/author/src/lib/modules/shared/components/confirm-dialog/confirm-dialog.component'
 
 import { ErrorParserComponent } from '@ws/author/src/lib/modules/shared/components/error-parser/error-parser.component'
-
 
 import { EditorContentService } from '@ws/author/src/lib/routing/modules/editor/services/editor-content.service'
 
@@ -61,7 +70,6 @@ import { NSContent } from '@ws/author/src/lib/interface/content'
 
 import { NSApiRequest } from '@ws/author/src/lib/interface/apiRequest'
 
-
 import { CONTENT_BASE_WEBHOST } from '@ws/author/src/lib/constants/apiEndpoints'
 
 import { VIEWER_ROUTE_FROM_MIME } from '@ws-widget/collection/src/public-api'
@@ -98,9 +106,7 @@ interface QuizQuestion {
   styleUrls: ['./quiz.component.scss'],
   providers: [QuizResolverService, QuizStoreService],
 })
-
 export class QuizComponent implements OnInit, OnChanges, OnDestroy {
-
   selectedQuizIndex!: number
   allContents: NSContent.IContentMeta[] = []
   contentLoaded = false
@@ -173,30 +179,26 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
     private quizResolverSvc: QuizResolverService,
     private accessControl: AccessControlService,
   ) {
-
-    this.initService.uploadMessage.subscribe(
-      (data: any) => {
-        if (data !== 'save') {
-          this.save()
-        }
-      })
-    this.initService.updateAssessmentMessage.subscribe(
-      (data: any) => {
-        if (data) {
-          this.metaContentService.currentContent = data.identifier
-          console.log("data: ", data)
-          this.ngOnInit()
-        }
-      })
-    this.initService.isAssessmentOrQuizMessage.subscribe(
-      (data: any) => {
-        if (data == false) {
-          this.isQuiz = 'Assessment'
-        } else {
-          this.isQuiz = 'Quiz'
-        }
-      })
-    console.log("Quiz12", this.isQuiz)
+    this.initService.uploadMessage.subscribe((data: any) => {
+      if (data !== 'save') {
+        this.save()
+      }
+    })
+    this.initService.updateAssessmentMessage.subscribe((data: any) => {
+      if (data) {
+        this.metaContentService.currentContent = data.identifier
+        console.log('data: ', data)
+        this.ngOnInit()
+      }
+    })
+    this.initService.isAssessmentOrQuizMessage.subscribe((data: any) => {
+      if (data == false) {
+        this.isQuiz = 'Assessment'
+      } else {
+        this.isQuiz = 'Quiz'
+      }
+    })
+    console.log('Quiz12', this.isQuiz)
     // this.activeIndexSubscription = this.quizStoreSvc.selectedQuizIndex.subscribe(index => {
     //   const val = this.quizStoreSvc.getQuiz(index)
     //   console.log("val of type", val)
@@ -309,7 +311,7 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
    */
 
   ngOnInit() {
-    (async () => {
+    ;(async () => {
       this.showSettingButtons = true
       this.isLoading = false
       // console.log('kk', JSON.parse(sessionStorage.assessment))
@@ -317,16 +319,19 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
       console.log("sessionStorage.getItem('quiz')", sessionStorage.getItem('quiz'))
 
       // Safety net: dismiss global loader if async chain doesn't complete within 3s
-      setTimeout(() => { this.isLoading = false; this.loaderService.changeLoad.next(false) }, 3000)
+      setTimeout(() => {
+        this.isLoading = false
+        this.loaderService.changeLoad.next(false)
+      }, 3000)
 
       this.activeContentSubscription = this.metaContentService.changeActiveCont.subscribe(id => {
-        console.log("code", code)
+        console.log('code', code)
         // Keep the global "Please wait..." loader visible until the quiz content
         // is actually loaded (contentLoaded below) — clearing it here left a blank
         // page while the assessment JSON was still being fetched.
         if (code) {
           this.isEdited = true
-          id = JSON.parse(code)  // use real assessment ID for all subsequent lookups
+          id = JSON.parse(code) // use real assessment ID for all subsequent lookups
           this.metaContentService.currentContent = id
         } else {
           this.metaContentService.currentContent = id
@@ -366,16 +371,18 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
               if (this.courseCompetency) {
                 this.isQuiz = 'Assessment'
               }
-              console.log("Quiz12", this.isQuiz)
+              console.log('Quiz12', this.isQuiz)
 
-              console.log("this is quiz", v.contents[0].content, this.isQuiz)
+              console.log('this is quiz', v.contents[0].content, this.isQuiz)
               this.resourceName = quizContent ? quizContent.name : 'Resource'
               this.resourceDetails = quizContent
-              console.log("quizContent", quizContent, this.metaContentService.currentContent, this.resourceName)
+              console.log('quizContent', quizContent, this.metaContentService.currentContent, this.resourceName)
               // console.log(quizContent)
               if (quizContent && quizContent.mimeType === 'application/json') {
-                const fileData = ((quizContent.artifactUrl || quizContent.downloadUrl) ?
-                  this.quizResolverSvc.getJSON(this.generateUrl(quizContent.artifactUrl || quizContent.downloadUrl)) : of({} as any))
+                const fileData =
+                  quizContent.artifactUrl || quizContent.downloadUrl
+                    ? this.quizResolverSvc.getJSON(this.generateUrl(quizContent.artifactUrl || quizContent.downloadUrl))
+                    : of({} as any)
                 fileData.subscribe(jsonResponse => {
                   // this.isLoading = false
                   //console.log('jsonResponse ', jsonResponse)
@@ -388,27 +395,40 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
                         if (jsonResponse.passPercentage >= 0) {
                           this.validPercentage = true
                         }
-                        console.log("jsonResponse.isAssessment:", jsonResponse.isAssessment, "quizContent.competency:", quizContent.competency)
+                        console.log(
+                          'jsonResponse.isAssessment:',
+                          jsonResponse.isAssessment,
+                          'quizContent.competency:',
+                          quizContent.competency,
+                        )
 
                         if (jsonResponse.isAssessment === true && quizContent.competency) {
-                          console.log("Condition 1 met")
+                          console.log('Condition 1 met')
                           this.isQuiz = 'Assessment'
                         } else if (this.courseCompetency === true) {
-                          console.log("Condition 2 met")
+                          console.log('Condition 2 met')
                           this.isQuiz = 'Assessment'
                         } else {
-                          console.log("Condition 3 met")
+                          console.log('Condition 3 met')
                           this.validPercentage = true
                           this.isQuiz = 'Quiz'
                         }
 
-                        console.log("this.isQuiz 1", this.isQuiz)
-                        this.assessmentDuration = (jsonResponse.timeLimit) / 60
+                        console.log('this.isQuiz 1', this.isQuiz)
+                        this.assessmentDuration = jsonResponse.timeLimit / 60
                         this.passPercentage = jsonResponse.passPercentage
                         this.randomCount = jsonResponse.randomCount
                       }
                       this.allContents.push(v.contents[0].content)
-                      if (v.contents[0].data) {
+                      // This loader can re-run (changeActiveCont re-emits) while the author has
+                      // unsaved question edits — e.g. a just-uploaded image not yet persisted.
+                      // Overwriting collectiveQuiz[id] with backend data would wipe those edits
+                      // from the editor (the reported "image disappears sometimes" — the in-memory
+                      // model is correct, but a background reload resets it). Preserve in-memory
+                      // questions in that case; a fresh load or post-save reload proceeds normally.
+                      if (this.shouldPreserveUnsavedQuestions(id)) {
+                        // keep unsaved in-memory edits; do not overwrite from backend
+                      } else if (v.contents[0].data) {
                         this.quizStoreSvc.collectiveQuiz[id] = v.contents[0].data.questions
                       } else if (newData[0] && newData[0].data && newData[0].data.questions) {
                         this.quizStoreSvc.collectiveQuiz[id] = newData[0].data.questions
@@ -424,8 +444,7 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
                             // this.passPercentage = '50'
                             // this.quizStoreSvc.assessmentDuration = jsonResponse.timeLimit
                             // this.quizStoreSvc.passPercentage = jsonResponse.passPercentage
-                            this.questionsArr =
-                              this.quizStoreSvc.collectiveQuiz[id] || []
+                            this.questionsArr = this.quizStoreSvc.collectiveQuiz[id] || []
                             this.contentLoaded = true
                             this.loaderService.changeLoad.next(false)
                             this.questionsArr = this.quizStoreSvc.collectiveQuiz[id]
@@ -446,8 +465,7 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
                       this.canEditJson = this.quizResolverSvc.canEdit(quizContent)
                       this.resourceType = quizContent.categoryType || 'Assessment'
                       this.quizDuration = quizContent.duration
-                      this.questionsArr =
-                        this.quizStoreSvc.collectiveQuiz[id] || []
+                      this.questionsArr = this.quizStoreSvc.collectiveQuiz[id] || []
                       this.contentLoaded = true
                       this.loaderService.changeLoad.next(false)
                     }
@@ -462,15 +480,13 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
                     this.canEditJson = this.quizResolverSvc.canEdit(quizContent)
                     this.resourceType = quizContent.categoryType || 'Assessment'
                     this.quizDuration = quizContent.duration
-                    this.questionsArr =
-                      this.quizStoreSvc.collectiveQuiz[id] || []
+                    this.questionsArr = this.quizStoreSvc.collectiveQuiz[id] || []
                     this.contentLoaded = true
                     this.loaderService.changeLoad.next(false)
                     if (!this.quizStoreSvc.collectiveQuiz[id]) {
                       this.quizStoreSvc.collectiveQuiz[id] = []
                     }
-                    console.log("yessfasdf", quizContent)
-
+                    console.log('yessfasdf', quizContent)
                   }
                   if (quizContent.isAssessment) {
                     this.isQuiz = 'Assessment'
@@ -480,10 +496,10 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
                   }
                   if (this.courseCompetency) {
                     this.isQuiz = 'Assessment'
-                    console.log("this.isQuiz 1", this.isQuiz)
-                    this.cdr.detectChanges()  // Manually trigger change detection
+                    console.log('this.isQuiz 1', this.isQuiz)
+                    this.cdr.detectChanges() // Manually trigger change detection
                   }
-                  console.log("this.isQuiz 1", this.isQuiz)
+                  console.log('this.isQuiz 1', this.isQuiz)
                 })
               }
               if (v.contents[0].content.competency) {
@@ -510,20 +526,17 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
         }
         if (this.courseCompetency) {
           this.isQuiz = 'Assessment'
-          console.log("this.isQuiz 1", this.isQuiz)
-          this.cdr.detectChanges()  // Manually trigger change detection
+          console.log('this.isQuiz 1', this.isQuiz)
+          this.cdr.detectChanges() // Manually trigger change detection
         }
-        console.log("Quiz", this.isQuiz)
+        console.log('Quiz', this.isQuiz)
       })
     })()
   }
   isAtLeastOneQuestionPresent(): boolean {
     return this.questionsArr.some((question: any) => {
       // Check if the question text is non-empty or if at least one option has text
-      return (
-        question.question.trim() !== '' &&
-        question.options.some((option: any) => option.text.trim() !== '')
-      )
+      return question.question.trim() !== '' && question.options.some((option: any) => option.text.trim() !== '')
     })
   }
   uploadFileModal(): void {
@@ -533,7 +546,7 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
         data: 'uploadFile',
       })
 
-      confirmDelete.afterClosed().subscribe((confirm) => {
+      confirmDelete.afterClosed().subscribe(confirm => {
         if (confirm && this.uploadFile && this.uploadFile.nativeElement) {
           this.uploadFile.nativeElement.click()
         }
@@ -541,7 +554,6 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
     } else {
       this.uploadFile.nativeElement.click()
     }
-
   }
   convertExcelToJson(file: File): void {
     const validExtensions = ['xlsx', 'xls'] // Allowed extensions
@@ -572,7 +584,6 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
       console.log('Generated Quiz JSON 2:', this.questionsArr)
       this.cdr.detectChanges()
       this.cdr.markForCheck() // Explicitly mark the component for change detection
-
     }
     reader.readAsArrayBuffer(file)
   }
@@ -657,7 +668,7 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
         multiSelection, // Assign the boolean value
       })
     }
-    console.log("quizJson", quizJson)
+    console.log('quizJson', quizJson)
     return quizJson
   }
   downloadTemplate(): void {
@@ -714,7 +725,7 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
   }
   addTodo(event: any, field: string) {
     const meta: any = {}
-    console.log("event", event)
+    console.log('event', event)
     if (event > 100) {
       // Reset the input value to 100
       this.passPercentage = 100
@@ -745,7 +756,6 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
         this.assessmentDuration = event
         this.quizStoreSvc.hasChanged = true
       }
-
     }
     this.metaContentService.setUpdatedMeta(meta, this.currentId, true)
   }
@@ -807,41 +817,39 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
 
   createInAnotherLanguage(lang: string) {
     this.loaderService.changeLoad.next(true)
-    this.metaContentService
-      .createInAnotherLanguage(lang, { artifactURL: '', downloadUrl: '' })
-      .subscribe(
-        data => {
-          this.loaderService.changeLoad.next(false)
-          if (data !== true) {
-            this.allContents.push(data as NSContent.IContentMeta)
-            this.changeContent(data as NSContent.IContentMeta)
-            this.showNotification(Notify.CONTENT_CREATE_SUCCESS)
-          } else {
-            this.showNotification(Notify.DATA_PRESENT)
-          }
-        },
-        error => {
-          if (error.status === 409) {
-            const errorMap = new Map<string, NSContent.IContentMeta>()
-            errorMap.set(this.currentId, this.metaContentService.getUpdatedMeta(this.currentId))
-            this.dialog.open(ErrorParserComponent, {
-              width: '750px',
-              height: '450px',
-              data: {
-                errorFromBackendData: error.error,
-                dataMapping: errorMap,
-              },
-            })
-          }
-          this.loaderService.changeLoad.next(false)
-          this.snackBar.openFromComponent(NotificationComponent, {
+    this.metaContentService.createInAnotherLanguage(lang, { artifactURL: '', downloadUrl: '' }).subscribe(
+      data => {
+        this.loaderService.changeLoad.next(false)
+        if (data !== true) {
+          this.allContents.push(data as NSContent.IContentMeta)
+          this.changeContent(data as NSContent.IContentMeta)
+          this.showNotification(Notify.CONTENT_CREATE_SUCCESS)
+        } else {
+          this.showNotification(Notify.DATA_PRESENT)
+        }
+      },
+      error => {
+        if (error.status === 409) {
+          const errorMap = new Map<string, NSContent.IContentMeta>()
+          errorMap.set(this.currentId, this.metaContentService.getUpdatedMeta(this.currentId))
+          this.dialog.open(ErrorParserComponent, {
+            width: '750px',
+            height: '450px',
             data: {
-              type: Notify.CONTENT_FAIL,
+              errorFromBackendData: error.error,
+              dataMapping: errorMap,
             },
-            duration: NOTIFICATION_TIME * 1000,
           })
-        },
-      )
+        }
+        this.loaderService.changeLoad.next(false)
+        this.snackBar.openFromComponent(NotificationComponent, {
+          data: {
+            type: Notify.CONTENT_FAIL,
+          },
+          duration: NOTIFICATION_TIME * 1000,
+        })
+      },
+    )
   }
 
   triggerSave(meta: NSContent.IContentMeta, id: string) {
@@ -865,7 +873,7 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
     let isAssessment = this.resourceDetails.isAssessment
     //For assessment and quiz
     if (this.isQuiz === 'Assessment') {
-      console.log("yes Assessment")
+      console.log('yes Assessment')
       isAssessment = true
     } else {
       isAssessment = false
@@ -883,24 +891,23 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
         request: {
           content: {
             ...meta,
-            isAssessment: isAssessment
-          }
-        }
+            isAssessment: isAssessment,
+          },
+        },
       }
       // tslint:disable-next-line:no-console
       console.log(requestBody)
-      this.editorService.updateNewContentV3(requestBody, this.currentId).subscribe(
-        (data: any) => {
-          // tslint:disable-next-line:no-console
-          console.log(data)
-        })
+      this.editorService.updateNewContentV3(requestBody, this.currentId).subscribe((data: any) => {
+        // tslint:disable-next-line:no-console
+        console.log(data)
+      })
     }
     return of({} as any)
   }
 
   generateUrl(oldUrl: any) {
     // @ts-ignore: Unreachable code error
-    let bucket = window["env"]["azureBucket"]
+    let bucket = window['env']['azureBucket']
     if (oldUrl.includes(bucket)) {
       return oldUrl
     }
@@ -977,54 +984,57 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
     if (!(this.metaContentService.getUpdatedMeta(this.currentId) || {}).duration) {
       this.metaContentService.setUpdatedMeta({ duration: this.quizDuration } as any, this.currentId)
     }
-    return (doUploadJson
-      ? this.triggerUpload(JSON.parse(JSON.stringify(updatedQuizData)))
-      : of({} as any)
-      // ).pipe(map(v => v.result))
-    ).pipe(mergeMap(v => {
-      // tslint:disable-next-line:no-console
-      console.log(v)
-      // tslint:disable-next-line: no-parameter-reassignment
-      v = v[0].result || v[0]
-      this.showNotification(Notify.SAVE_SUCCESS)
-      const updatedMeta: any = this.metaContentService.upDatedContent[this.currentId] || {}
-      // const check = this.resourceType === ASSESSMENT ? v.length && v[1] && v[1].code : true
-      // if (v && v[0] && v[0].code && check) {
-      if (v && (v.artifactUrl || v.content_url)) {
-        updatedMeta.artifactUrl = this.generateUrl(v.authArtifactUrl || v.artifactUrl)
-        updatedMeta.versionKey = v.versionKey
-        // this.quizDuration = this.metaContentService.getUpdatedMeta(this.currentId).duration
-        updatedMeta.downloadUrl = this.generateUrl(v.content_url)
-        this.quizStoreSvc.hasChanged = false
-        // this.editorService.readContentV2(this.currentId).subscribe(resData => {
-        //   this.metaContentService.resetOriginalMeta(resData, this.currentId)
-        //   this.metaContentService.resetVersionKey(resData.versionKey, resData.identifier)
-        //   this.loaderService.changeLoad.next(true)
-        // }, () => {
-        //   this.loaderService.changeLoad.next(true)
-        //   this.snackBar.open('Error Occured! Please refresh the page.')
-        // })
-        // this.metaContentService.setUpdatedMeta(updatedMeta, this.currentId)
-        // tslint:disable-next-line:no-console
-        console.log(updatedMeta, this.currentId)
-        this.editorService.readContentV2(this.currentId).subscribe(resData => {
-          updatedMeta["versionKey"] = resData.versionKey
-          updatedMeta["duration"] = isNumber(this.assessmentDuration) ?
-            (this.assessmentDuration * 60).toString() : this.assessmentDuration
-          return this.triggerSave(updatedMeta, this.currentId)
-        })
-      }
-      return EMPTY
+    return (
+      (doUploadJson ? this.triggerUpload(JSON.parse(JSON.stringify(updatedQuizData))) : of({} as any))
+        // ).pipe(map(v => v.result))
+        .pipe(
+          mergeMap(v => {
+            // tslint:disable-next-line:no-console
+            console.log(v)
+            // tslint:disable-next-line: no-parameter-reassignment
+            v = v[0].result || v[0]
+            this.showNotification(Notify.SAVE_SUCCESS)
+            const updatedMeta: any = this.metaContentService.upDatedContent[this.currentId] || {}
+            // const check = this.resourceType === ASSESSMENT ? v.length && v[1] && v[1].code : true
+            // if (v && v[0] && v[0].code && check) {
+            if (v && (v.artifactUrl || v.content_url)) {
+              updatedMeta.artifactUrl = this.generateUrl(v.authArtifactUrl || v.artifactUrl)
+              updatedMeta.versionKey = v.versionKey
+              // this.quizDuration = this.metaContentService.getUpdatedMeta(this.currentId).duration
+              updatedMeta.downloadUrl = this.generateUrl(v.content_url)
+              this.quizStoreSvc.hasChanged = false
+              // this.editorService.readContentV2(this.currentId).subscribe(resData => {
+              //   this.metaContentService.resetOriginalMeta(resData, this.currentId)
+              //   this.metaContentService.resetVersionKey(resData.versionKey, resData.identifier)
+              //   this.loaderService.changeLoad.next(true)
+              // }, () => {
+              //   this.loaderService.changeLoad.next(true)
+              //   this.snackBar.open('Error Occured! Please refresh the page.')
+              // })
+              // this.metaContentService.setUpdatedMeta(updatedMeta, this.currentId)
+              // tslint:disable-next-line:no-console
+              console.log(updatedMeta, this.currentId)
+              this.editorService.readContentV2(this.currentId).subscribe(resData => {
+                updatedMeta['versionKey'] = resData.versionKey
+                updatedMeta['duration'] = isNumber(this.assessmentDuration)
+                  ? (this.assessmentDuration * 60).toString()
+                  : this.assessmentDuration
+                return this.triggerSave(updatedMeta, this.currentId)
+              })
+            }
+            return EMPTY
 
-      // }
-    })
+            // }
+          }),
+        )
     )
   }
 
   save() {
     this.canValidate = true
-    const hasMinLen = (this.resourceType !== ASSESSMENT && this.questionsArr.length)
-      || (this.resourceType === ASSESSMENT && this.questionsArr.length >= this.quizConfig.minQues)
+    const hasMinLen =
+      (this.resourceType !== ASSESSMENT && this.questionsArr.length) ||
+      (this.resourceType === ASSESSMENT && this.questionsArr.length >= this.quizConfig.minQues)
     // const needSave = Object.keys(this.metaContentService.upDatedContent[this.currentId] || { }).length
     //   || this.quizStoreSvc.hasChanged
     const needSave = this.quizStoreSvc.hasChanged
@@ -1054,10 +1064,7 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
       if (this.resourceType !== ASSESSMENT && !this.questionsArr.length) {
         this.showNotification(Notify.RESOURCE_NO_QUIZ)
         this.currentStep = 2
-      } else if (
-        this.resourceType === ASSESSMENT &&
-        this.questionsArr.length < this.quizConfig.minQues
-      ) {
+      } else if (this.resourceType === ASSESSMENT && this.questionsArr.length < this.quizConfig.minQues) {
         this.showNotification(Notify.ASSESSMENT_MIN_QUIZ)
         // this.currentStep = 2
       } else {
@@ -1085,15 +1092,17 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
   uploadJson(array: any[], fileName: string) {
     // tslint:disable-next-line:no-console
     console.log(this.assessmentDuration, this.passPercentage, this.isQuiz, this.courseDetails)
-    this.quizDuration = (this.metaContentService.getUpdatedMeta(this.currentId).duration &&
-      this.metaContentService.getUpdatedMeta(this.currentId).duration !== '0') ?
-      this.metaContentService.getUpdatedMeta(this.currentId).duration : this.assessmentDuration
+    this.quizDuration =
+      this.metaContentService.getUpdatedMeta(this.currentId).duration &&
+      this.metaContentService.getUpdatedMeta(this.currentId).duration !== '0'
+        ? this.metaContentService.getUpdatedMeta(this.currentId).duration
+        : this.assessmentDuration
     this.passPercentage = this.isQuiz === 'Quiz' ? 0 : this.passPercentage
-    console.log("this.course", this.courseCompetency, this.isQuiz)
+    console.log('this.course', this.courseCompetency, this.isQuiz)
     let isAssessment = this.resourceDetails.isAssessment
     //For assessment and quiz
     if (this.isQuiz === 'Assessment') {
-      console.log("yes Assessment")
+      console.log('yes Assessment')
       isAssessment = true
     } else {
       isAssessment = false
@@ -1107,7 +1116,7 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
     const quizData = {
       // tslint:disable-next-line: prefer-template
       //timeLimit: parseInt(this.quizDuration + '', 10) || 300
-      timeLimit: (this.assessmentDuration) * 60,
+      timeLimit: this.assessmentDuration * 60,
       //assessmentDuration: (this.assessmentDuration) * 60 || '300',
       passPercentage: this.passPercentage,
       isAssessment: isAssessment,
@@ -1177,14 +1186,20 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
     this.resourceType = this.metaContentService.getUpdatedMeta(this.currentId).categoryType
     const uploadData = this.resourceType === ASSESSMENT ? dataWithOutAns : dataWithAns
     return forkJoin([
-      this.uploadJson(
-        uploadData,
-        this.resourceType === ASSESSMENT ? ASSESSMENT_JSON_WITHOUT_KEY : QUIZ_JSON,
-      ),
-      this.resourceType === ASSESSMENT
-        ? this.uploadJson(dataWithAns, ASSESSMENT_JSON_WITH_KEY)
-        : of({} as any),
+      this.uploadJson(uploadData, this.resourceType === ASSESSMENT ? ASSESSMENT_JSON_WITHOUT_KEY : QUIZ_JSON),
+      this.resourceType === ASSESSMENT ? this.uploadJson(dataWithAns, ASSESSMENT_JSON_WITH_KEY) : of({} as any),
     ])
+  }
+
+  // True when a reload should NOT overwrite the in-memory questions for this content: the store
+  // is dirty (unsaved edits) and already holds questions for this id. Prevents a background
+  // reload from wiping unsaved edits (e.g. a freshly inserted image) out of the editor.
+  shouldPreserveUnsavedQuestions(id: string): boolean {
+    return !!(
+      this.quizStoreSvc.hasChanged &&
+      Array.isArray(this.quizStoreSvc.collectiveQuiz[id]) &&
+      this.quizStoreSvc.collectiveQuiz[id].length > 0
+    )
   }
 
   action(type: string) {
@@ -1279,15 +1294,10 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
   preview() {
     if (this.resourceType === ASSESSMENT && this.questionsArr.length === 0) {
       this.showNotification(Notify.RESOURCE_NO_QUIZ)
-    } else if (
-      this.resourceType === ASSESSMENT &&
-      this.questionsArr.length < this.quizConfig.minQues
-    ) {
+    } else if (this.resourceType === ASSESSMENT && this.questionsArr.length < this.quizConfig.minQues) {
       this.showNotification(Notify.ASSESSMENT_MIN_QUIZ)
     } else {
-      const needSave =
-        this.quizStoreSvc.hasChanged ||
-        Object.keys(this.metaContentService.upDatedContent[this.currentId] || {}).length
+      const needSave = this.quizStoreSvc.hasChanged || Object.keys(this.metaContentService.upDatedContent[this.currentId] || {}).length
       if (needSave) {
         this.checkValidity()
         if (this.isValid) {
@@ -1295,9 +1305,7 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
             () => {
               this.loaderService.changeLoad.next(false)
               this.previewMode = true
-              this.mimeTypeRoute = VIEWER_ROUTE_FROM_MIME(
-                this.metaContentService.getUpdatedMeta(this.currentId).mimeType as any,
-              )
+              this.mimeTypeRoute = VIEWER_ROUTE_FROM_MIME(this.metaContentService.getUpdatedMeta(this.currentId).mimeType as any)
             },
             () => {
               this.loaderService.changeLoad.next(false)
@@ -1307,9 +1315,7 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
         }
       } else {
         this.previewMode = true
-        this.mimeTypeRoute = VIEWER_ROUTE_FROM_MIME(
-          this.metaContentService.getUpdatedMeta(this.currentId).mimeType as any,
-        )
+        this.mimeTypeRoute = VIEWER_ROUTE_FROM_MIME(this.metaContentService.getUpdatedMeta(this.currentId).mimeType as any)
       }
     }
   }
@@ -1320,17 +1326,13 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
       returnValue = false
       this.currentStep = 2
       this.showNotification(Notify.RESOURCE_NO_QUIZ)
-    } else if (
-      this.resourceType === ASSESSMENT &&
-      this.questionsArr.length < this.quizConfig.minQues
-    ) {
+    } else if (this.resourceType === ASSESSMENT && this.questionsArr.length < this.quizConfig.minQues) {
       returnValue = false
       this.showNotification(Notify.ASSESSMENT_MIN_QUIZ)
       this.currentStep = 2
     } else if (
       !this.metaContentService.isValid(this.currentId) ||
-      (!this.metaContentService.isValid(this.currentId) &&
-        !this.metaContentService.getUpdatedMeta(this.currentId).artifactUrl)
+      (!this.metaContentService.isValid(this.currentId) && !this.metaContentService.getUpdatedMeta(this.currentId).artifactUrl)
     ) {
       this.submitPressed = true
       this.showNotification(Notify.MANDATORY_FIELD_ERROR)
@@ -1347,9 +1349,7 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   takeAction() {
-    const needSave =
-      Object.keys(this.metaContentService.upDatedContent[this.currentId] || {}).length ||
-      this.quizStoreSvc.hasChanged
+    const needSave = Object.keys(this.metaContentService.upDatedContent[this.currentId] || {}).length || this.quizStoreSvc.hasChanged
     if (!needSave && this.metaContentService.getUpdatedMeta(this.currentId).status === 'Live') {
       this.showNotification(Notify.UP_TO_DATE)
       return
@@ -1374,16 +1374,12 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   isPublisherSame(): boolean {
-    const publisherDetails =
-      this.metaContentService.getUpdatedMeta(this.currentId).publisherDetails || []
+    const publisherDetails = this.metaContentService.getUpdatedMeta(this.currentId).publisherDetails || []
     return publisherDetails.find(v => v.id === this.accessControl.userId) ? true : false
   }
 
   isDirectPublish(): boolean {
-    return (
-      ['Draft', 'Live'].includes(this.metaContentService.originalContent[this.currentId].status) &&
-      this.isPublisherSame()
-    )
+    return ['Draft', 'Live'].includes(this.metaContentService.originalContent[this.currentId].status) && this.isPublisherSame()
   }
 
   finalCall(commentsForm: FormGroup) {
@@ -1392,11 +1388,9 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
         comment: commentsForm.controls.comments.value,
         operation:
           commentsForm.controls.action.value === 'accept' ||
-            ['Draft', 'Live'].includes(
-              this.metaContentService.originalContent[this.currentId].status,
-            )
+          ['Draft', 'Live'].includes(this.metaContentService.originalContent[this.currentId].status)
             ? ((this.accessControl.authoringConfig.isMultiStepFlow && this.isDirectPublish()) ||
-              !this.accessControl.authoringConfig.isMultiStepFlow) &&
+                !this.accessControl.authoringConfig.isMultiStepFlow) &&
               this.accessControl.rootOrg.toLowerCase() === 'client1'
               ? 100000
               : 1
@@ -1405,34 +1399,18 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
 
       const updatedContent: any = this.metaContentService.upDatedContent[this.currentId] || {}
       const updatedMeta: any = this.metaContentService.getUpdatedMeta(this.currentId)
-      const needSave = Object.keys(this.metaContentService.upDatedContent[this.currentId] || {})
-        .length
-      const saveCall = (needSave
-        ? this.triggerSave(updatedContent, this.currentId)
-        : of({} as any)
-      ).pipe(
+      const needSave = Object.keys(this.metaContentService.upDatedContent[this.currentId] || {}).length
+      const saveCall = (needSave ? this.triggerSave(updatedContent, this.currentId) : of({} as any)).pipe(
         mergeMap(() =>
-          this.editorService
-            .forwardBackward(
-              body,
-              this.currentId,
-              this.metaContentService.originalContent[this.currentId].status,
-            )
-            .pipe(
-              mergeMap(() =>
-                this.notificationSvc
-                  .triggerPushPullNotification(
-                    updatedMeta,
-                    body.comment,
-                    body.operation ? true : false,
-                  )
-                  .pipe(
-                    catchError(() => {
-                      return of({} as any)
-                    }),
-                  ),
+          this.editorService.forwardBackward(body, this.currentId, this.metaContentService.originalContent[this.currentId].status).pipe(
+            mergeMap(() =>
+              this.notificationSvc.triggerPushPullNotification(updatedMeta, body.comment, body.operation ? true : false).pipe(
+                catchError(() => {
+                  return of({} as any)
+                }),
               ),
             ),
+          ),
         ),
       )
       this.loaderService.changeLoad.next(true)
@@ -1455,10 +1433,7 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
         error => {
           if (error.status === 409) {
             const errorMap = new Map<string, NSContent.IContentMeta>()
-            errorMap.set(
-              this.currentId,
-              this.metaContentService.getUpdatedMeta(this.currentId),
-            )
+            errorMap.set(this.currentId, this.metaContentService.getUpdatedMeta(this.currentId))
             this.dialog.open(ErrorParserComponent, {
               width: '80vw',
               height: '90vh',
@@ -1540,10 +1515,11 @@ export class QuizComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   canDelete() {
-    return this.accessControl.hasRole(['editor', 'admin']) ||
+    return (
+      this.accessControl.hasRole(['editor', 'admin']) ||
       (['Draft', 'Live'].includes(this.metaContentService.originalContent[this.currentId].status) &&
-        this.metaContentService.originalContent[this.currentId].creatorContacts.find(v => v.id === this.accessControl.userId)
-      )
+        this.metaContentService.originalContent[this.currentId].creatorContacts.find(v => v.id === this.accessControl.userId))
+    )
   }
   // fullScreenToggle() { }
 }

--- a/project/ws/author/src/lib/routing/modules/editor/shared/components/plain-ckeditor/plain-ckeditor.component.spec.ts
+++ b/project/ws/author/src/lib/routing/modules/editor/shared/components/plain-ckeditor/plain-ckeditor.component.spec.ts
@@ -1,0 +1,247 @@
+import { PlainCKEditorComponent } from './plain-ckeditor.component'
+
+// The component is CKEditor-heavy and its template needs the global CKEDITOR + a real DOM host,
+// which are brittle under jsdom. Per the project convention for heavy components, we instantiate
+// the class directly with mocked collaborators and a stubbed global CKEDITOR, and test the
+// toolbar-button wiring logic (the part restored after the Angular migration dropped it).
+describe('PlainCKEditorComponent - custom upload toolbar buttons', () => {
+  let component: PlainCKEditorComponent
+  let addImageSpy: jest.SpyInstance
+  let addFileSpy: jest.SpyInstance
+  let addBlankSpy: jest.SpyInstance
+
+  const accessControlSvc: any = { locale: 'en', rootOrg: 'root', org: 'org', userId: 'u1', userName: 'user' }
+
+  beforeEach(() => {
+    // Reset the once-only plugin registration guard between tests.
+    ;(PlainCKEditorComponent as any).uploadPluginRegistered = false
+
+    component = new PlainCKEditorComponent(
+      {} as any, // snackBar
+      {} as any, // uploadService
+      {} as any, // configurationSvc
+      accessControlSvc,
+      {} as any, // loaderService
+      { detach: jest.fn(), detectChanges: jest.fn() } as any, // cdr
+      {} as any, // http
+    )
+
+    // Stub the upload handlers so the config callbacks are observable without running upload logic.
+    addImageSpy = jest.spyOn(component, 'addImageUploadBtn').mockImplementation(() => undefined)
+    addFileSpy = jest.spyOn(component, 'addFileUploadBtn').mockImplementation(() => undefined)
+    addBlankSpy = jest.spyOn(component, 'addBlankBtn').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    delete (global as any).CKEDITOR
+    document.getElementById('ws-ck-upload-icons')?.remove()
+    jest.restoreAllMocks()
+  })
+
+  describe('uploadToolbarConfig()', () => {
+    it('declares the wsuploads plugin and routes callbacks to the existing handlers', () => {
+      const cfg: any = component.uploadToolbarConfig()
+
+      expect(cfg.extraPlugins).toBe('wsuploads')
+      expect(typeof cfg.wsOnUploadImage).toBe('function')
+      expect(typeof cfg.wsOnUploadFile).toBe('function')
+      expect(typeof cfg.wsOnAddBlank).toBe('function')
+
+      cfg.wsOnUploadImage()
+      cfg.wsOnUploadFile()
+      cfg.wsOnAddBlank()
+
+      expect(addImageSpy).toHaveBeenCalledTimes(1)
+      expect(addFileSpy).toHaveBeenCalledTimes(1)
+      expect(addBlankSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('initiateConfig() / allConfig()', () => {
+    it('adds the wsuploads plugin to both the basic and advanced configs', () => {
+      component.initiateConfig()
+      component.allConfig()
+
+      expect(component.config.extraPlugins).toBe('wsuploads')
+      expect(component.configsecond.extraPlugins).toBe('wsuploads')
+    })
+  })
+
+  describe('registerUploadPlugin()', () => {
+    function stubCkeditor() {
+      const added: { name?: string; def?: any } = {}
+      ;(global as any).CKEDITOR = {
+        plugins: {
+          add: jest.fn((name: string, def: any) => {
+            added.name = name
+            added.def = def
+          }),
+        },
+      }
+      return added
+    }
+
+    it('registers a single "wsuploads" plugin that adds the three insert-group buttons', () => {
+      const added = stubCkeditor()
+
+      component.registerUploadPlugin()
+
+      expect((global as any).CKEDITOR.plugins.add).toHaveBeenCalledTimes(1)
+      expect(added.name).toBe('wsuploads')
+
+      // Drive the plugin init with a fake editor and assert the commands + buttons it creates.
+      const commands: Record<string, any> = {}
+      const fakeEditor: any = {
+        config: {
+          wsOnUploadImage: jest.fn(),
+          wsOnUploadFile: jest.fn(),
+          wsOnAddBlank: jest.fn(),
+        },
+        addCommand: jest.fn((name: string, def: any) => (commands[name] = def)),
+        ui: { addButton: jest.fn() },
+      }
+      added.def.init(fakeEditor)
+
+      expect(fakeEditor.ui.addButton).toHaveBeenCalledWith(
+        'WsUploadImage',
+        expect.objectContaining({ command: 'wsUploadImageCmd', toolbar: 'insert' }),
+      )
+      expect(fakeEditor.ui.addButton).toHaveBeenCalledWith(
+        'WsUploadFile',
+        expect.objectContaining({ command: 'wsUploadFileCmd', toolbar: 'insert' }),
+      )
+      expect(fakeEditor.ui.addButton).toHaveBeenCalledWith(
+        'WsAddBlank',
+        expect.objectContaining({ command: 'wsAddBlankCmd', toolbar: 'insert' }),
+      )
+
+      // Executing the image command must invoke the per-instance handler from editor config.
+      commands['wsUploadImageCmd'].exec(fakeEditor)
+      expect(fakeEditor.config.wsOnUploadImage).toHaveBeenCalledTimes(1)
+    })
+
+    it('injects a stylesheet with data-URI backgrounds for the three button icons', () => {
+      stubCkeditor()
+
+      component.registerUploadPlugin()
+
+      const style = document.getElementById('ws-ck-upload-icons')
+      expect(style).not.toBeNull()
+      const css = style!.textContent || ''
+      expect(css).toContain('.cke_button__wsuploadimage_icon')
+      expect(css).toContain('.cke_button__wsuploadfile_icon')
+      expect(css).toContain('.cke_button__wsaddblank_icon')
+      expect(css).toContain('data:image/svg+xml;base64,')
+      expect(css).toContain('!important')
+    })
+
+    it('is idempotent - does not re-register the plugin on repeated calls', () => {
+      stubCkeditor()
+
+      component.registerUploadPlugin()
+      component.registerUploadPlugin()
+
+      expect((global as any).CKEDITOR.plugins.add).toHaveBeenCalledTimes(1)
+    })
+
+    it('no-ops safely when CKEDITOR is unavailable', () => {
+      expect((global as any).CKEDITOR).toBeUndefined()
+      expect(() => component.registerUploadPlugin()).not.toThrow()
+      expect((PlainCKEditorComponent as any).uploadPluginRegistered).toBe(false)
+    })
+  })
+
+  describe('insertImageHtml()', () => {
+    it('focuses the editor, inserts a well-formed img, and emits the new content', () => {
+      const editor: any = {
+        focus: jest.fn(),
+        insertHtml: jest.fn(),
+        getData: jest.fn().mockReturnValue('<p><img src="x"></p>'),
+      }
+      component.editorInstance = editor
+      const emitted: string[] = []
+      component.value.subscribe(v => emitted.push(v))
+
+      component.insertImageHtml('/content/asset/pic.png')
+
+      // Focus must happen before insertHtml (the dialog stole focus → no selection otherwise).
+      expect(editor.focus).toHaveBeenCalled()
+      expect(editor.insertHtml).toHaveBeenCalledTimes(1)
+      const html = editor.insertHtml.mock.calls[0][0]
+      expect(html).toMatch(/^<img alt="" src=".+" \/>$/)
+      // The plain asset URL is inserted as-is (so the <img> loads immediately); it is NOT
+      // wrapped in the AUTHORING_CONTENT_BASE proxy/encoded form, which failed to render.
+      expect(html).toContain('src="/content/asset/pic.png"')
+      // Content is synced from the editor and propagated to the parent.
+      expect(emitted.length).toBeGreaterThan(0)
+    })
+
+    it('no-ops when there is no editor instance', () => {
+      component.editorInstance = null
+      expect(() => component.insertImageHtml('/x.png')).not.toThrow()
+    })
+
+    it('destroys an orphan editor bound to the same host before creating a new one', () => {
+      const host = {}
+      const orphan = { element: { $: host }, destroy: jest.fn() }
+      const other = { element: { $: {} }, destroy: jest.fn() }
+      ;(global as any).CKEDITOR = { instances: { editor1: orphan, editor2: other } }
+      ;(component as any).destroyEditorsOnHost(host)
+
+      // Only the instance bound to this exact host element is destroyed.
+      expect(orphan.destroy).toHaveBeenCalledWith(true)
+      expect(other.destroy).not.toHaveBeenCalled()
+    })
+
+    it('restores the caret captured at click time, then inserts', () => {
+      const bookmarks = [{ startOffset: 3 }]
+      const selection = {
+        getRanges: jest.fn().mockReturnValue([{}]),
+        createBookmarks2: jest.fn().mockReturnValue(bookmarks),
+        selectBookmarks: jest.fn(),
+      }
+      const editor: any = {
+        getSelection: jest.fn().mockReturnValue(selection),
+        focus: jest.fn(),
+        fire: jest.fn(),
+        insertHtml: jest.fn(),
+        setData: jest.fn((_d: string, opts: any) => opts && opts.callback && opts.callback()),
+        getData: jest.fn().mockReturnValue(''),
+      }
+      component.editorInstance = editor
+
+      // Simulate the button click snapshotting the selection before the file dialog opens.
+      ;(component as any).captureEditorSelection()
+      expect(selection.createBookmarks2).toHaveBeenCalledWith(true)
+
+      component.insertImageHtml('/x.png')
+
+      expect(selection.selectBookmarks).toHaveBeenCalledWith(bookmarks)
+      expect(editor.insertHtml).toHaveBeenCalledTimes(1)
+    })
+
+    it('falls back to the end of the editable when no caret was captured', () => {
+      const range = { moveToElementEditEnd: jest.fn() }
+      const selection = { selectRanges: jest.fn() }
+      const editable = {}
+      const editor: any = {
+        getSelection: jest.fn().mockReturnValue(selection),
+        editable: jest.fn().mockReturnValue(editable),
+        createRange: jest.fn().mockReturnValue(range),
+        focus: jest.fn(),
+        fire: jest.fn(),
+        insertHtml: jest.fn(),
+        setData: jest.fn((_d: string, opts: any) => opts && opts.callback && opts.callback()),
+        getData: jest.fn().mockReturnValue(''),
+      }
+      component.editorInstance = editor
+
+      // No captureEditorSelection() call → savedBookmarks stays null → fallback path.
+      component.insertImageHtml('/x.png')
+
+      expect(range.moveToElementEditEnd).toHaveBeenCalledWith(editable)
+      expect(selection.selectRanges).toHaveBeenCalledWith([range])
+      expect(editor.insertHtml).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/project/ws/author/src/lib/routing/modules/editor/shared/components/plain-ckeditor/plain-ckeditor.component.ts
+++ b/project/ws/author/src/lib/routing/modules/editor/shared/components/plain-ckeditor/plain-ckeditor.component.ts
@@ -26,11 +26,7 @@ import { NOTIFICATION_TIME } from '@ws/author/src/lib/constants/constant'
 
 import { Notify } from '@ws/author/src/lib/constants/notificationMessage'
 
-import {
-  FILE_MAX_SIZE,
-  IMAGE_MAX_SIZE,
-  IMAGE_SUPPORT_TYPES,
-} from '@ws/author/src/lib/constants/upload'
+import { FILE_MAX_SIZE, IMAGE_MAX_SIZE, IMAGE_SUPPORT_TYPES } from '@ws/author/src/lib/constants/upload'
 
 import { NotificationComponent } from '@ws/author/src/lib/modules/shared/components/notification/notification.component'
 
@@ -48,8 +44,18 @@ import { HttpClient } from '@angular/common/http'
 
 import { AUTHORING_BASE } from '@ws/author/src/lib/constants/apiEndpoints'
 
-
 declare const CKEDITOR: any
+
+// Inline 16x16 SVG icons (base64 data URIs) for the custom insert-toolbar buttons.
+// Kept inline because the pre-migration icon sprite (/assets/authoring/ckeditor/plugins/icons.png)
+// no longer ships with the app.
+const WS_UPLOAD_ICONS = {
+  image:
+    'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IiM0NDQiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIj48cmVjdCB4PSIzIiB5PSIzIiB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHJ4PSIyIi8+PGNpcmNsZSBjeD0iOC41IiBjeT0iOC41IiByPSIxLjYiLz48cGF0aCBkPSJNMjEgMTZsLTQuNS00LjVMNSAyMSIvPjwvc3ZnPg==',
+  file: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IiM0NDQiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIj48cGF0aCBkPSJNMTQgMkg2YTIgMiAwIDAgMC0yIDJ2MTZhMiAyIDAgMCAwIDIgMmgxMmEyIDIgMCAwIDAgMi0yVjh6Ii8+PHBhdGggZD0iTTE0IDJ2Nmg2Ii8+PC9zdmc+',
+  blank:
+    'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IiM0NDQiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIj48cGF0aCBkPSJNNCAxOGgxNiIvPjxwYXRoIGQ9Ik04IDE0aDgiLz48L3N2Zz4=',
+}
 
 @Component({
   standalone: false,
@@ -113,7 +119,12 @@ export class PlainCKEditorComponent implements AfterViewInit, OnInit, OnDestroy 
   @ViewChild('addBlank', { static: false }) blank!: ElementRef
   blankName = 'Add Blank'
   timer: any
-  showAdvancedSettings = false;
+  showAdvancedSettings = false
+  // The custom insert buttons are backed by one global CKEditor plugin; register it only once.
+  private static uploadPluginRegistered = false
+  // Editor selection captured when the upload button is clicked, so we can restore the caret
+  // after the native file dialog steals focus (otherwise insertHtml has no range to insert at).
+  private savedBookmarks: any = null
 
   subscription!: Subscription
   constructor(
@@ -124,7 +135,7 @@ export class PlainCKEditorComponent implements AfterViewInit, OnInit, OnDestroy 
     private loaderService: LoaderService,
     private cdr: ChangeDetectorRef,
     private http: HttpClient,
-  ) { }
+  ) {}
 
   ngOnInit() {
     this.allConfig()
@@ -169,6 +180,7 @@ export class PlainCKEditorComponent implements AfterViewInit, OnInit, OnDestroy 
       ],
       allowedContent: true,
       extraAllowedContent: 'a[!href,download,document-href,class]',
+      ...this.uploadToolbarConfig(),
       removeButtons:
         'Cut,Copy,Paste,PasteText,PasteFromWord,Save,NewPage,Preview,Print,' +
         'Templates,Scayt,Form,Checkbox,Radio,TextField,Textarea,Select,Button,HiddenField,ImageButton' +
@@ -222,6 +234,7 @@ export class PlainCKEditorComponent implements AfterViewInit, OnInit, OnDestroy 
       ],
       allowedContent: true,
       extraAllowedContent: 'a[!href,download,document-href,class]',
+      ...this.uploadToolbarConfig(),
       removeButtons:
         'Cut,Copy,Paste,PasteText,PasteFromWord,Save,NewPage,Preview,Print,' +
         'Templates,Scayt,Form,Checkbox,Radio,TextField,Textarea,Select,Button,HiddenField,ImageButton' +
@@ -249,6 +262,102 @@ export class PlainCKEditorComponent implements AfterViewInit, OnInit, OnDestroy 
     }
   }
 
+  // Config fragment that adds the custom insert-toolbar buttons (Upload Image / Upload File /
+  // Add Blank) and routes each button's command back to this component's existing handlers.
+  // The handlers already existed; only the toolbar wiring was lost in the Angular migration.
+  uploadToolbarConfig() {
+    return {
+      extraPlugins: 'wsuploads',
+      wsUploadImageLabel: this.imageName,
+      wsUploadFileLabel: this.fileName,
+      wsAddBlankLabel: this.blankName,
+      wsOnUploadImage: () => this.addImageUploadBtn(),
+      wsOnUploadFile: () => this.addFileUploadBtn(),
+      wsOnAddBlank: () => this.addBlankBtn(),
+    }
+  }
+
+  // CKEditor 4's CKEDITOR.getUrl() rewrites the button `icon` path by prefixing its base path,
+  // which corrupts a `data:` URI and leaves the icon blank. So we let CKEditor create the icon
+  // <span> (via the icon option) and override its background here with !important, which beats
+  // CKEditor's broken inline style. The icon class is `cke_button__<lowercased-name>_icon`.
+  private injectUploadIconStyles() {
+    if (typeof document === 'undefined') {
+      return
+    }
+    if (document.getElementById('ws-ck-upload-icons')) {
+      return
+    }
+    const rule = (name: string, uri: string) =>
+      `.cke_button__${name}_icon,.cke_button__${name} .cke_button_icon` +
+      `{background:url("${uri}") no-repeat center !important;background-size:16px 16px !important;}`
+    const style = document.createElement('style')
+    style.id = 'ws-ck-upload-icons'
+    style.textContent =
+      rule('wsuploadimage', WS_UPLOAD_ICONS.image) + rule('wsuploadfile', WS_UPLOAD_ICONS.file) + rule('wsaddblank', WS_UPLOAD_ICONS.blank)
+    document.head.appendChild(style)
+  }
+
+  // Registers the single global CKEditor plugin that exposes the three custom buttons in the
+  // 'insert' toolbar group. Each button's command reads its handler from the per-instance
+  // editor config, so one shared plugin drives every editor instance correctly.
+  registerUploadPlugin() {
+    if (PlainCKEditorComponent.uploadPluginRegistered) {
+      return
+    }
+    if (typeof CKEDITOR === 'undefined' || !CKEDITOR.plugins || !CKEDITOR.plugins.add) {
+      return
+    }
+    this.injectUploadIconStyles()
+    const specs = [
+      {
+        btn: 'WsUploadImage',
+        cmd: 'wsUploadImageCmd',
+        handler: 'wsOnUploadImage',
+        label: 'wsUploadImageLabel',
+        fallback: 'Upload Image',
+        icon: WS_UPLOAD_ICONS.image,
+      },
+      {
+        btn: 'WsUploadFile',
+        cmd: 'wsUploadFileCmd',
+        handler: 'wsOnUploadFile',
+        label: 'wsUploadFileLabel',
+        fallback: 'Upload File',
+        icon: WS_UPLOAD_ICONS.file,
+      },
+      {
+        btn: 'WsAddBlank',
+        cmd: 'wsAddBlankCmd',
+        handler: 'wsOnAddBlank',
+        label: 'wsAddBlankLabel',
+        fallback: 'Add Blank',
+        icon: WS_UPLOAD_ICONS.blank,
+      },
+    ]
+    CKEDITOR.plugins.add('wsuploads', {
+      init(editor: any) {
+        specs.forEach(spec => {
+          editor.addCommand(spec.cmd, {
+            exec: (ed: any) => {
+              const handler = ed.config[spec.handler]
+              if (typeof handler === 'function') {
+                handler()
+              }
+            },
+          })
+          editor.ui.addButton(spec.btn, {
+            label: editor.config[spec.label] || spec.fallback,
+            command: spec.cmd,
+            toolbar: 'insert',
+            icon: spec.icon,
+          })
+        })
+      },
+    })
+    PlainCKEditorComponent.uploadPluginRegistered = true
+  }
+
   ngOnDestroy() {
     this._editorDestroyed = true
     if (this.editorInstance) {
@@ -270,12 +379,25 @@ export class PlainCKEditorComponent implements AfterViewInit, OnInit, OnDestroy 
   }
 
   private initEditor() {
-    if (this._editorDestroyed || !this.editorHost?.nativeElement) { return }
+    if (this._editorDestroyed || !this.editorHost?.nativeElement) {
+      return
+    }
     if (this.editorInstance) {
       this.editorInstance.destroy()
       this.editorInstance = null
     }
+    // Destroy any CKEditor still bound to this host element. Re-inits (e.g. ngAfterViewInit
+    // re-firing during an assessment reload) can otherwise leave an orphan instance: its editable
+    // stays in the DOM (what the user sees) while this.editorInstance — the one insertHtml/getData
+    // operate on — points elsewhere, so inserted images never appear on screen.
+    this.destroyEditorsOnHost(this.editorHost.nativeElement)
+    this.registerUploadPlugin()
     const cfg = this.showAdvancedSettings ? { ...this.configsecond } : { ...this.config }
+    // Labels come from the hidden i18n spans, which are only populated in ngAfterViewInit
+    // (after initiateConfig/allConfig ran in ngOnInit), so refresh them onto the live config.
+    cfg.wsUploadImageLabel = this.imageName
+    cfg.wsUploadFileLabel = this.fileName
+    cfg.wsAddBlankLabel = this.blankName
     this.editorInstance = CKEDITOR.replace(this.editorHost.nativeElement, cfg)
     this.editorInstance.on('instanceReady', () => {
       if (this.html) {
@@ -285,6 +407,25 @@ export class PlainCKEditorComponent implements AfterViewInit, OnInit, OnDestroy 
     this.editorInstance.on('change', () => {
       this.html = this.editorInstance.getData()
       this.onContentChanged()
+    })
+  }
+
+  // Destroys every CKEditor instance currently bound to the given host element, so exactly one
+  // live instance exists per editor and this.editorInstance is always the one rendered on screen.
+  private destroyEditorsOnHost(host: any) {
+    if (!host || typeof CKEDITOR === 'undefined' || !CKEDITOR.instances) {
+      return
+    }
+    Object.keys(CKEDITOR.instances).forEach(name => {
+      const inst = CKEDITOR.instances[name]
+      const el = inst && inst.element && inst.element.$
+      if (el === host) {
+        try {
+          inst.destroy(true)
+        } catch {
+          /* already gone */
+        }
+      }
     })
   }
 
@@ -327,6 +468,9 @@ export class PlainCKEditorComponent implements AfterViewInit, OnInit, OnDestroy 
   }
 
   addImageUploadBtn() {
+    // Toolbar clicks keep the editable focused, so the caret is still valid here — snapshot it
+    // before the file dialog (opened below) blurs the editor.
+    this.captureEditorSelection()
     const input = document.createElement('input')
     input.setAttribute('type', 'file')
     input.setAttribute('accept', IMAGE_SUPPORT_TYPES.toString())
@@ -352,7 +496,7 @@ export class PlainCKEditorComponent implements AfterViewInit, OnInit, OnDestroy 
             const fileName = file.name.replace(/[^A-Za-z0-9.]/g, '')
             form.set('content', file, file.name.replace(/[^A-Za-z0-9.]/g, ''))
             this.loaderService.changeLoad.next(true)
-            console.log("contentId: this.id, contentType: this.location", this.id, this.location)
+            console.log('contentId: this.id, contentType: this.location', this.id, this.location)
 
             let randomNumber = ''
             // tslint:disable-next-line: no-increment-decrement
@@ -376,66 +520,46 @@ export class PlainCKEditorComponent implements AfterViewInit, OnInit, OnDestroy 
               },
             }
 
-            this.http
-              .post<any>(
-                `${AUTHORING_BASE}content/v3/create`,
-                requestBody,
-              )
-              .subscribe(
-                (meta: any) => {
-                  // return data.result.identifier
-                  this.uploadService
-                    .upload(form, {
-                      contentId: meta.result.identifier,
-                      contentType: CONTENT_BASE_STATIC,
+            this.http.post<any>(`${AUTHORING_BASE}content/v3/create`, requestBody).subscribe((meta: any) => {
+              // return data.result.identifier
+              this.uploadService
+                .upload(form, {
+                  contentId: meta.result.identifier,
+                  contentType: CONTENT_BASE_STATIC,
+                })
+
+                .subscribe(
+                  data => {
+                    if (data && data.name !== 'Error') {
+                      this.loaderService.changeLoad.next(false)
+                      this.snackBar.openFromComponent(NotificationComponent, {
+                        data: {
+                          type: Notify.UPLOAD_SUCCESS,
+                        },
+                        duration: NOTIFICATION_TIME * 2000,
+                      })
+                      console.log('yes here', data)
+                      let url = data.artifactUrl
+                      if (!this.doRegex) {
+                        url = `/${url.split('/').slice(3).join('/')}`
+                      }
+                      this.insertImageHtml(url)
+                    } else {
+                      this.loaderService.changeLoad.next(false)
+                      this.snackBar.open(data.message, undefined, { duration: 2000 })
+                    }
+                  },
+                  () => {
+                    this.loaderService.changeLoad.next(false)
+                    this.snackBar.openFromComponent(NotificationComponent, {
+                      data: {
+                        type: Notify.UPLOAD_FAIL,
+                      },
+                      duration: NOTIFICATION_TIME * 1000,
                     })
-
-                    .subscribe(
-                      data => {
-                        if (data && data.name !== 'Error') {
-
-                          this.loaderService.changeLoad.next(false)
-                          this.snackBar.openFromComponent(NotificationComponent, {
-                            data: {
-                              type: Notify.UPLOAD_SUCCESS,
-                            },
-                            duration: NOTIFICATION_TIME * 2000,
-                          })
-                          console.log("yes here", data)
-                          let url = data.artifactUrl
-                          if (!this.doRegex) {
-                            url = `/${url.split('/').slice(3).join('/')}`
-                          }
-                          this.editorInstance?.insertHtml(
-                            `<img alt='' src=${AUTHORING_CONTENT_BASE}${encodeURIComponent(
-                              url,
-                            )}></img>`,
-                          )
-                          console.log("url: ", url)
-                          // })
-                        } else {
-                          this.loaderService.changeLoad.next(false)
-                          this.snackBar.open(data.message, undefined, { duration: 2000 })
-
-                        }
-                      },
-                      () => {
-                        this.loaderService.changeLoad.next(false)
-                        this.snackBar.openFromComponent(NotificationComponent, {
-                          data: {
-                            type: Notify.UPLOAD_FAIL,
-                          },
-                          duration: NOTIFICATION_TIME * 1000,
-                        })
-                      },
-                    )
-
-                },
-              )
-
-
-
-
+                  },
+                )
+            })
 
             // this.uploadService
             //   .upload(form, { contentId: this.id, contentType: this.location })
@@ -492,6 +616,62 @@ export class PlainCKEditorComponent implements AfterViewInit, OnInit, OnDestroy 
     input.click()
   }
 
+  // Inserts the uploaded image into the editor. Called from the async upload callback, by which
+  // point the file-picker dialog has stolen focus from the editable — so insertHtml() would have
+  // no selection and silently do nothing. Focusing first restores a valid selection, and syncing
+  // this.html + emitting guarantees the new content reaches the parent quiz store.
+  insertImageHtml(url: string) {
+    const editor = this.editorInstance
+    if (!editor) {
+      return
+    }
+    // Insert the asset's plain URL so the <img> loads and paints immediately. The previous
+    // `AUTHORING_CONTENT_BASE + encodeURIComponent(url)` form produced a proxied, percent-encoded
+    // src (/apis/authContent/https%3A%2F%2F...) that did not resolve, so a freshly inserted image
+    // stayed blank until an echo/reload rewrote it to the plain URL. The stored value is identical
+    // either way — onContentChanged's uploadRegex only rewrites the AUTHORING_CONTENT_BASE form,
+    // and a plain URL passes through unchanged.
+    const img = `<img alt="" src="${url}" />`
+    if (editor.focus) {
+      editor.focus()
+    }
+    this.restoreOrPlaceSelection(editor)
+    this.savedBookmarks = null
+    editor.insertHtml(img)
+    this.html = editor.getData ? editor.getData() : this.html
+    this.onContentChanged()
+  }
+
+  // Snapshots the current editor selection as serializable bookmarks (survive DOM/HTML changes).
+  private captureEditorSelection() {
+    const editor = this.editorInstance
+    const sel = editor && editor.getSelection ? editor.getSelection() : null
+    this.savedBookmarks = sel && sel.getRanges && sel.getRanges().length && sel.createBookmarks2 ? sel.createBookmarks2(true) : null
+  }
+
+  // Restores the caret captured before the file dialog; if none was captured (user never placed
+  // the cursor in the editor), falls back to the end of the editable so insertHtml has a range.
+  private restoreOrPlaceSelection(editor: any) {
+    const sel = editor.getSelection ? editor.getSelection() : null
+    if (this.savedBookmarks && sel && sel.selectBookmarks) {
+      try {
+        sel.selectBookmarks(this.savedBookmarks)
+        return
+      } catch {
+        // fall through to end-of-editable placement
+      }
+    }
+    const editable = editor.editable ? editor.editable() : null
+    if (editable && editor.createRange && editor.getSelection) {
+      const range = editor.createRange()
+      range.moveToElementEditEnd(editable)
+      const selection = editor.getSelection()
+      if (selection && selection.selectRanges) {
+        selection.selectRanges([range])
+      }
+    }
+  }
+
   addFileUploadBtn() {
     const input = document.createElement('input')
     input.setAttribute('type', 'file')
@@ -516,41 +696,37 @@ export class PlainCKEditorComponent implements AfterViewInit, OnInit, OnDestroy 
             const form = new FormData()
             form.set('content', file, file.name.replace(/[^A-Za-z0-9.]/g, ''))
             this.loaderService.changeLoad.next(true)
-            this.uploadService
-              .upload(form, { contentId: this.id, contentType: this.location })
-              .subscribe(
-                data => {
-                  // if (data.code) {
-                  //   let url = data.artifactURL
-                  if (data.result) {
-                    let url = data.result.artifactUrl
-                    if (this.doRegex) {
-                      url = `/${url.split('/').slice(3).join('/')}`
-                    }
-                    this.editorInstance?.insertHtml(
-                      `<a href='${url}' download>Click here to download</a>`,
-                    )
-                    this.snackBar.openFromComponent(NotificationComponent, {
-                      data: {
-                        type: Notify.UPLOAD_SUCCESS,
-                      },
-                      duration: NOTIFICATION_TIME * 1000,
-                    })
-                    input.remove()
-                    this.loaderService.changeLoad.next(false)
+            this.uploadService.upload(form, { contentId: this.id, contentType: this.location }).subscribe(
+              data => {
+                // if (data.code) {
+                //   let url = data.artifactURL
+                if (data.result) {
+                  let url = data.result.artifactUrl
+                  if (this.doRegex) {
+                    url = `/${url.split('/').slice(3).join('/')}`
                   }
-                },
-                () => {
-                  this.loaderService.changeLoad.next(false)
+                  this.editorInstance?.insertHtml(`<a href='${url}' download>Click here to download</a>`)
                   this.snackBar.openFromComponent(NotificationComponent, {
                     data: {
-                      type: Notify.UPLOAD_FAIL,
+                      type: Notify.UPLOAD_SUCCESS,
                     },
                     duration: NOTIFICATION_TIME * 1000,
                   })
                   input.remove()
-                },
-              )
+                  this.loaderService.changeLoad.next(false)
+                }
+              },
+              () => {
+                this.loaderService.changeLoad.next(false)
+                this.snackBar.openFromComponent(NotificationComponent, {
+                  data: {
+                    type: Notify.UPLOAD_FAIL,
+                  },
+                  duration: NOTIFICATION_TIME * 1000,
+                })
+                input.remove()
+              },
+            )
           } else {
             input.remove()
             this.snackBar.openFromComponent(NotificationComponent, {


### PR DESCRIPTION
## Summary

The Angular migration dropped the custom upload controls from the plain-ckeditor (used by the quiz/assessment question editor, edit-meta description, web-page editor). This restores **Upload Image / Upload File / Add Blank** in the editor's `insert` toolbar and fixes the issues that surfaced while restoring them.

## Changes
- Re-register the three custom buttons as one global CKEditor 4 plugin (`wsuploads`), wired to the existing `addImageUploadBtn` / `addFileUploadBtn` / `addBlankBtn` handlers.
- Inject data-URI SVG icons via a stylesheet (CKEDITOR.getUrl mangles `data:` URIs passed as the button `icon`, leaving it blank).
- Insert the asset's **plain URL** so the `<img>` loads and paints immediately; the previous `AUTHORING_CONTENT_BASE + encodeURIComponent(...)` form produced a proxied, percent-encoded src that didn't resolve, so a freshly inserted image stayed blank until an echo/reload rewrote it. Stored value is unchanged.
- Restore the caret after the file dialog blurs the editor; guarantee a single live editor instance per host.
- `quiz.component`: don't overwrite in-memory questions with backend data on a background reload when there are unsaved edits (`shouldPreserveUnsavedQuestions`) — this was wiping just-inserted images before save.

## Tests
- New `plain-ckeditor.component.spec.ts` (plugin wiring, icon injection, insertion, caret restore, single-instance guard).
- New `shouldPreserveUnsavedQuestions` tests in `quiz.component.spec.ts`.

## Verification
- Lint: 0 errors
- Jest: 59 suites / 301 tests pass, coverage threshold met
- Production build: succeeds (dist/www/en)
- Manually verified in-app: multiple images insert and stay; persist on save and reload.