### PR TITLE
chore(sonar): scope SonarCloud analysis to app source + wire coverage

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,19 +1,43 @@
-name: Build
-# Manual-only. This ran on every push/PR and failed at "SonarQube Scan" because no
-# SONAR_TOKEN secret is configured — going red on every change and duplicating the
-# "Quality" workflow. Run it on demand once the token is set (Settings → Secrets →
-# SONAR_TOKEN), or re-enable the push/pull_request triggers then.
+name: SonarCloud
+
+# Manual-only until a SONAR_TOKEN secret is configured. This job used to run on
+# every push/PR and failed at "SonarQube Scan" because no SONAR_TOKEN exists —
+# going red on every change. Once the token is set (Settings → Secrets and
+# variables → Actions → SONAR_TOKEN), swap `workflow_dispatch` for the
+# push/pull_request triggers below so analysis (incl. coverage) runs per PR.
 on:
   workflow_dispatch:
+  # Enable these once SONAR_TOKEN is set:
+  # push:
+  #   branches: [main]
+  # pull_request:
+  #   branches: [main]
+  #   types: [opened, synchronize, reopened]
+
 jobs:
   SonarCloud:
     name: SonarCloud
     runs-on: ubuntu-latest
-    environment : SONAR_TOKEN
+    environment: SONAR_TOKEN
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+          # Disable shallow clone for better relevancy of blame/new-code analysis.
+          fetch-depth: 0
+
+      # Coverage must be generated BEFORE the scan so sonar can read
+      # coverage/lcov.info (wired via sonar.javascript.lcov.reportPaths in
+      # sonar-project.properties). Node 20 matches the runtime and the version
+      # the Jest suite is validated on. package-lock.json is gitignored and there
+      # is a known jest 29 vs 30 peer conflict, so use --legacy-peer-deps.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm install --legacy-peer-deps --no-audit --no-fund
+      - name: Jest (produce coverage/lcov.info)
+        run: npm test -- --coverage --ci
+
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v5
         env:

--- a/docs/sonarqube-remediation.md
+++ b/docs/sonarqube-remediation.md
@@ -1,0 +1,87 @@
+# SonarQube / SonarCloud Remediation — Runbook
+
+Project: **`Sphere_sunbird-cb-creationportal-old`** (org `sphere`, SonarCloud).
+
+Goal: bring **Security**, **Reliability**, and **Security Review (Hotspots)** to **A** on Overall
+Code, lift **line coverage to 60%**, and reduce duplication — **without removing any feature
+or changing behavior**. This is a phased program; this doc is the operational runbook. Phase 0
+(scan scoping) is implemented by `sonar-project.properties` and `.github/workflows/sonarcloud.yml`.
+
+## How Sonar ratings work (so we fix the right things)
+
+| Rating          | A means                    | Implication here                                                                                       |
+| --------------- | -------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Reliability     | **0 Bugs**                 | Every Bug must be fixed or dispositioned (Won't-fix / false-positive).                                 |
+| Security        | **0 Vulnerabilities**      | Fix/disposition all 6.                                                                                 |
+| Security Review | **≥80% Hotspots reviewed** | Mark each Hotspot **Safe** or **Fixed** — a triage action, not always code.                            |
+| Maintainability | debt-ratio (not count)     | Already **A**. `console.*` and `as any` are _smells_ here, **not** Bugs — low priority for the rating. |
+
+## Phase 0 — scan scope + coverage wiring (done in this change)
+
+`sonar-project.properties` now:
+
+- Scopes analysis to the real source tiers: `sonar.sources=src/app,project/ws,library/ws-widget`
+  (this excludes vendored bundles `ckeditor.js` / `telemetry.min.js` / `zip.js`, the committed
+  `dist/` server, legacy `e2e/`, and root configs by omission).
+- Registers `*.spec.ts` as tests, not sources.
+- Excludes `**/*.min.js`, `**/karma.conf.js`, `**/*.d.ts`, `**/assets/**`, `**/environments/**`.
+- Wires coverage: `sonar.javascript.lcov.reportPaths=coverage/lcov.info`.
+- Keeps NgModules/routing/models/barrels out of the **coverage** denominator
+  (`sonar.coverage.exclusions`), mirroring `jest.config.js` `collectCoverageFrom`.
+
+> Note: `project/ws/author/src/lib/constants/init.ts` (4,649 lines, ~1,591 `as any`) is **not**
+> excluded. It's hand-maintained static config (a single `const`, zero functions), so its casts
+> are Maintainability _smells_ (already grade A) — irrelevant to the target ratings — and as pure
+> data it contributes ~1 executable statement, so it barely affects coverage. Excluding a real
+> source file would be gaming for no benefit.
+
+## Running a scan
+
+### Preferred (CI, once the token exists)
+
+1. Repo → Settings → Secrets and variables → Actions → add **`SONAR_TOKEN`** (SonarCloud → My
+   Account → Security → generate token).
+2. In `.github/workflows/sonarcloud.yml`, uncomment the `push` / `pull_request` triggers.
+3. Trigger via **Actions → SonarCloud → Run workflow** (or open a PR). The job installs deps,
+   runs `npm test -- --coverage --ci` to produce `coverage/lcov.info`, then scans.
+
+### Local / manual (token-later)
+
+```bash
+# 1) generate coverage (Node 20; deps via --legacy-peer-deps)
+npm install --legacy-peer-deps
+npm test -- --coverage        # writes coverage/lcov.info
+
+# 2) run the scanner (needs a token in the env; does NOT touch the app)
+export SONAR_TOKEN=<your-sonarcloud-token>
+npx sonar-scanner            # or: docker run --rm -e SONAR_TOKEN -v "$PWD:/usr/src" sonarsource/sonar-scanner-cli
+```
+
+The scanner reads `sonar-project.properties`, so no extra flags are needed.
+
+## Exporting the issue list (the input to Phases 2–3)
+
+After a scoped re-scan, export the residual findings — this sizes and sequences the fix work:
+
+- **UI:** Issues tab → filter _Type = Bug_ and _Type = Vulnerability_; Security Hotspots tab →
+  review queue. Export from the UI where available.
+- **API:** `GET api/issues/search?componentKeys=Sphere_sunbird-cb-creationportal-old&types=BUG&ps=500`
+  (and `types=VULNERABILITY`), `GET api/hotspots/search?projectKey=Sphere_sunbird-cb-creationportal-old`.
+
+## Phases 1–4 (summary)
+
+1. **Hotspots E→A** — review the queue by rule; mark **Safe** (with justification) for non-security
+   uses (e.g. `Math.random` DOM ids, trusted `innerHTML`/`bypassSecurityTrust`/`window.location`),
+   **fix** genuinely unsafe ones. Cross 80% reviewed → rating A.
+2. **Vulns D→A** — fix/disposition the 6.
+3. **Reliability E→A** — fix Bugs in tested batches by rule (mechanical `==`→`===` and
+   identical-branch first; then empty catches, timing, unsubscribed observables). Iterate to 0.
+4. **Coverage 8.3%→60%** — ratcheted milestones (services/pipes → small components → big author
+   components via direct-instantiation `build()` pattern → viewer tier), bumping the
+   `jest.config.js` `coverageThreshold` after each milestone. Extract the duplicated stepper arrays
+   into a tested factory (cuts duplication + adds coverage).
+
+## Guardrails (every code PR)
+
+Branch from `main`; one issue-category per PR; ship tests; keep `npm run lint`, `npm test -- --coverage`
+and `npm run build` all green; re-scan and confirm the target count dropped with **no new** issues.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,14 +1,40 @@
 sonar.projectKey=Sphere_sunbird-cb-creationportal-old
 sonar.organization=sphere
 
-
 # This is the name and version displayed in the SonarCloud UI.
 #sonar.projectName=sunbird-cb-creationportal-old
 #sonar.projectVersion=1.0
 
+sonar.sourceEncoding=UTF-8
 
-# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-#sonar.sources=.
+# --- Analysis scope ---------------------------------------------------------
+# Analyze ONLY the three real application source tiers. Previously this was
+# unset, so the scanner defaulted to the repo root (".") and analyzed vendored
+# third-party bundles (src/assets/authoring/ckeditor/ckeditor.js,
+# src/cbp-assets/telemetry.min.js, src/assets/authoring/zip-js/zip.js), the
+# committed dist/ Express server, the legacy e2e/ (protractor) tree and the
+# per-project karma.conf.js files — inflating the Bug / Hotspot / smell counts
+# with code we neither own nor ship from these sources. Scoping to the tiers
+# below excludes all of that by omission (they live outside these paths).
+sonar.sources=src/app,project/ws,library/ws-widget
 
-# Encoding of the source code. Default is default system encoding
-#sonar.sourceEncoding=UTF-8
+# Unit tests are the *.spec.ts files; register them as tests (not main sources)
+# so their assertions aren't analyzed as production code.
+sonar.tests=.
+sonar.test.inclusions=**/*.spec.ts
+
+# Belt-and-suspenders exclusions for non-application files that live *inside*
+# the source tiers above (e.g. each project keeps a legacy karma.conf.js), plus
+# anything vendored/minified/declaration-only.
+sonar.exclusions=**/*.spec.ts,**/*.min.js,**/karma.conf.js,**/*.d.ts,**/assets/**,**/environments/**
+
+# --- Coverage ---------------------------------------------------------------
+# Wire the Jest lcov report (produced by `npm test -- --coverage`, written to
+# coverage/lcov.info by Jest's default reporters). Without this, SonarCloud
+# coverage was disconnected from the suite.
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+
+# Keep untestable boilerplate out of the coverage denominator, mirroring the
+# negatives in jest.config.js `collectCoverageFrom` (NgModules, routing, DTO
+# models, barrels, env files) so the coverage % reflects real, testable code.
+sonar.coverage.exclusions=**/*.module.ts,**/*-routing.module.ts,**/*.routing.ts,**/*.model.ts,**/public-api.ts,**/index.ts,**/environments/**


### PR DESCRIPTION
**Phase 0 of the SonarQube A-grade program — configuration only, no application code touched.**

## Why
`sonar-project.properties` set no `sonar.sources`, no exclusions, and no coverage path, so SonarCloud analyzed the **repo root**: vendored bundles (`ckeditor.js`, `telemetry.min.js`, `zip.js`), the committed `dist/` Express server, legacy `e2e/`, and per-project `karma.conf.js` all counted toward the Bug / Hotspot / smell totals — and coverage was disconnected from the Jest suite. That mis-scope inflates the Reliability (770) and Hotspot (98) counts with code we don't own or ship from these paths.

## What changed
- **`sonar-project.properties`**
  - `sonar.sources=src/app,project/ws,library/ws-widget` — analyze only the real app tiers (excludes vendored/build/e2e trees by omission).
  - Register `*.spec.ts` as **tests**, not sources.
  - `sonar.exclusions` for `**/*.min.js`, `**/karma.conf.js`, `**/*.d.ts`, `**/assets/**`, `**/environments/**`.
  - Wire coverage: `sonar.javascript.lcov.reportPaths=coverage/lcov.info`.
  - `sonar.coverage.exclusions` keeps NgModules/routing/models/barrels out of the coverage denominator (mirrors `jest.config.js` `collectCoverageFrom`).
- **`.github/workflows/sonarcloud.yml`** — generate coverage (`npm test -- --coverage --ci`, Node 20) **before** the scan; documented enabling `push`/`pull_request` triggers once `SONAR_TOKEN` is set (stays `workflow_dispatch` until then).
- **`docs/sonarqube-remediation.md`** — runbook: how ratings work, how to run/verify a scan (CI + manual), how to export the issue list, and the phase plan.

## Not excluded (deliberately)
`project/ws/author/src/lib/constants/init.ts` (4,649 lines, ~1,591 `as any`) stays analyzed — it's hand-maintained static config (one `const`, zero functions), so its casts are Maintainability **smells** (already grade A), not Bugs, and as pure data it barely affects coverage. Excluding a real source file would be gaming for no benefit.

## Risk
None to the app — only Sonar config, a manual CI workflow, and docs. No `.ts`/`.html`/build inputs touched. The Quality gate (lint/test/build) still applies to this PR.

## Follow-ups (tracked in the runbook)
- Add `SONAR_TOKEN` secret to automate scans and enable PR triggers.
- Re-scan, export the residual Bug/Vuln/Hotspot list → sizes Phases 1–4.
